### PR TITLE
fix(ci/cd): fetch entire git history

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -13,6 +13,8 @@ jobs:
         steps:
             - name: Checkout code
               uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
 
             - name: Set up Node.js
               uses: actions/setup-node@v4
@@ -29,7 +31,6 @@ jobs:
               run: |
                   git config --global user.name "GitHub Actions"
                   git config --global user.email "actions@github.com"
-                  git subtree pull --prefix dist origin deploy || true
                   git add -A -f dist/.
                   git commit -m "build: PR #${{ github.event.pull_request.number }}"
                   git subtree push --prefix dist origin deploy


### PR DESCRIPTION
For some reason, I'm getting the following error:

hint: Updates were rejected because the remote contains work that you do not
hint: have locally. This is usually caused by another repository pushing to
hint: the same ref. If you want to integrate the remote changes, use
hint: 'git pull' before pushing again.
hint: See the 'Note about fast-forwards' in 'git push --help' for details.

when trying to push to the subtree. I believe it may be that the entire git history is not being fetched due to actions/checkout fetch depth being set to 1 by default. I'm going to try to fetch the entire history and see if that does it.