### PR TITLE
fix(ci/cd): pull existing deploy subtree directory prior to building

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -21,8 +21,8 @@ jobs:
 
             - name: Fetch and add deploy branch subtree
               run: |
-                git fetch origin deploy || true
-                git subtree add --prefix dist deploy || true
+                  git fetch origin deploy || true
+                  git subtree add --prefix dist deploy || true
               # We don't need to create the subtree here if it doesn't exist - git subtree push, below, can handle it.
 
             - name: Install dependencies

--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -19,6 +19,12 @@ jobs:
               with:
                   node-version: "20.x"
 
+            - name: Fetch and add deploy branch subtree
+              run: |
+                git fetch origin deploy || true
+                git subtree add --prefix dist deploy || true
+              # We don't need to create the subtree here if it doesn't exist - git subtree push, below, can handle it.
+
             - name: Install dependencies
               run: npm install
 
@@ -29,7 +35,6 @@ jobs:
               run: |
                   git config --global user.name "GitHub Actions"
                   git config --global user.email "actions@github.com"
-                  git fetch origin deploy
                   git add -A -f dist/.
                   git commit -m "build: PR #${{ github.event.pull_request.number }}"
                   git subtree push --prefix dist origin deploy


### PR DESCRIPTION
My previous fixes were doing nothing to address the core problem. Originally, I thought it was that it wasn't fetching the history for the dist directory - However, I realized that the dist directory does not exist on new pulls / checkouts. Here, I resolve this by pulling the existing deploy branch into the dist/ directory prior to running npm run build. The change seems to have worked locally, so hopefully it will work via github actions.