### PR TITLE
Mobile Friendliness Update

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,10 +11,10 @@ const Backdrop = styled.div`
     display: grid;
     grid-template-areas:
         "top"
-        "menus"
         "empty"
+        "menus"
         "buttons";
-    grid-template-rows: 50px 320px 1fr min-content;
+    grid-template-rows: 50px 1fr 200px min-content;
     grid-template-columns: 1fr;
     height: 100%;
     width: 100%;
@@ -128,8 +128,6 @@ export function App() {
                     setLeaderboardShown={setLeaderboardShown}
                     settingsMenuShown={settingsMenuShown}
                     setSettingsMenuShown={setSettingsMenuShown}
-                    starLightState={starLightState}
-                    updateStarLight={updateStarLight}
                 />
                 {settingsMenuShown ? (
                     <SettingsMenu debugStatsShown={debugStatsShown} setDebugStatsShown={setDebugStatsShown} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { ControlButtons } from "./components/ControlButtons";
 import { SettingsMenu } from "./components/Settings";
 import { DebugStats } from "./components/DebugStats";
 import { Leaderboard, LeaderboardBody } from "./components/Leaderboard";
+import { MenuName} from "./lib/defines/MenuName";
 
 const Backdrop = styled.div`
     display: grid;
@@ -77,9 +78,8 @@ export function App() {
 
     // Display the bodies inside of the leaderboard menu. Sorted by order of mass by universe class.
     const [leaderboardBodies, setLeaderboardBodies] = useState<Array<LeaderboardBody>>([]);
-    const [leaderboardShown, setLeaderboardShown] = useState<boolean>(false);
-    const [settingsMenuShown, setSettingsMenuShown] = useState<boolean>(false);
     const [debugStatsShown, setDebugStatsShown] = useState<boolean>(false);
+    const [menuShown, setMenuShown] = useState<MenuName>(MenuName.NONE)
     return (
         <>
             <SimScreen>
@@ -113,7 +113,7 @@ export function App() {
                     />
                 ) : null}
 
-                {leaderboardShown ? (
+                {menuShown == MenuName.LEADERBOARD ? (
                     <Leaderboard
                         leaderboardBodies={leaderboardBodies}
                         bodyFollowed={bodyFollowed}
@@ -124,12 +124,10 @@ export function App() {
                     pausedState={pausedState}
                     updatePaused={updatePaused}
                     resetSim={resetSim}
-                    leaderboardShown={leaderboardShown}
-                    setLeaderboardShown={setLeaderboardShown}
-                    settingsMenuShown={settingsMenuShown}
-                    setSettingsMenuShown={setSettingsMenuShown}
+                    menuShown={menuShown}
+                    setMenuShown={setMenuShown}
                 />
-                {settingsMenuShown ? (
+                {menuShown == MenuName.SETTINGS ? (
                     <SettingsMenu
                         debugStatsShown={debugStatsShown}
                         setDebugStatsShown={setDebugStatsShown}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ const Backdrop = styled.div`
 const SimScreen = styled.div`
     position: absolute;
     height: 100vh;
-    width: 100%;
+    width: 100vw;
     z-index: 0;
 `;
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { ControlButtons } from "./components/ControlButtons";
 import { SettingsMenu } from "./components/Settings";
 import { DebugStats } from "./components/DebugStats";
 import { Leaderboard, LeaderboardBody } from "./components/Leaderboard";
-import { MenuName} from "./lib/defines/MenuName";
+import { MenuName } from "./lib/defines/MenuName";
 
 const Backdrop = styled.div`
     display: grid;
@@ -79,7 +79,7 @@ export function App() {
     // Display the bodies inside of the leaderboard menu. Sorted by order of mass by universe class.
     const [leaderboardBodies, setLeaderboardBodies] = useState<Array<LeaderboardBody>>([]);
     const [debugStatsShown, setDebugStatsShown] = useState<boolean>(false);
-    const [menuShown, setMenuShown] = useState<MenuName>(MenuName.NONE)
+    const [menuShown, setMenuShown] = useState<MenuName>(MenuName.NONE);
     return (
         <>
             <SimScreen>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,6 +79,7 @@ export function App() {
     const [leaderboardBodies, setLeaderboardBodies] = useState<Array<LeaderboardBody>>([]);
     const [leaderboardShown, setLeaderboardShown] = useState<boolean>(false);
     const [settingsMenuShown, setSettingsMenuShown] = useState<boolean>(false);
+    const [debugStatsShown, setDebugStatsShown] = useState<boolean>(false);
     return (
         <>
             <SimScreen>
@@ -100,15 +101,18 @@ export function App() {
             </SimScreen>
             <Backdrop>
                 <Header />
-                <DebugStats
-                    numActiveBodies={numActiveBodies}
-                    numStars={numStars}
-                    maxVertexUniformVectors={maxVertexUniformVectors}
-                    maxFragmentUniformVectors={maxFragmentUniformVectors}
-                    maxUniformBufferBindingPoints={maxUniformBufferBindingPoints}
-                    numActiveUniforms={numActiveUniforms}
-                    numActiveUniformVectors={numActiveUniformVectors}
-                />
+                {debugStatsShown ? (
+                    <DebugStats
+                        numActiveBodies={numActiveBodies}
+                        numStars={numStars}
+                        maxVertexUniformVectors={maxVertexUniformVectors}
+                        maxFragmentUniformVectors={maxFragmentUniformVectors}
+                        maxUniformBufferBindingPoints={maxUniformBufferBindingPoints}
+                        numActiveUniforms={numActiveUniforms}
+                        numActiveUniformVectors={numActiveUniformVectors}
+                    />
+                ) : null}
+
                 {leaderboardShown ? (
                     <Leaderboard
                         leaderboardBodies={leaderboardBodies}
@@ -127,7 +131,9 @@ export function App() {
                     starLightState={starLightState}
                     updateStarLight={updateStarLight}
                 />
-                {settingsMenuShown ? <SettingsMenu /> : null}
+                {settingsMenuShown ? (
+                    <SettingsMenu debugStatsShown={debugStatsShown} setDebugStatsShown={setDebugStatsShown} />
+                ) : null}
             </Backdrop>
         </>
     );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -130,7 +130,12 @@ export function App() {
                     setSettingsMenuShown={setSettingsMenuShown}
                 />
                 {settingsMenuShown ? (
-                    <SettingsMenu debugStatsShown={debugStatsShown} setDebugStatsShown={setDebugStatsShown} />
+                    <SettingsMenu
+                        debugStatsShown={debugStatsShown}
+                        setDebugStatsShown={setDebugStatsShown}
+                        starLightState={starLightState}
+                        updateStarLight={updateStarLight}
+                    />
                 ) : null}
             </Backdrop>
         </>

--- a/src/components/ControlButtons.tsx
+++ b/src/components/ControlButtons.tsx
@@ -7,7 +7,6 @@ import { SettingsIcon } from "../assets/icons/SettingsIcon";
 import { ViewListIcon } from "../assets/icons/ViewListIcon";
 import { MenuName } from "../lib/defines/MenuName";
 
-
 interface ControlButtonProps {
     pausedState: boolean;
     updatePaused: (shouldPause: boolean) => void;
@@ -17,20 +16,14 @@ interface ControlButtonProps {
 }
 
 export function ControlButtons(props: ControlButtonProps) {
-    const {
-        pausedState,
-        updatePaused,
-        resetSim,
-        menuShown,
-        setMenuShown
-    } = props;
+    const { pausedState, updatePaused, resetSim, menuShown, setMenuShown } = props;
     return (
         <ButtonContainer>
             <ButtonRow>
                 <ControlButton
                     dim={"50px"}
                     onClick={() => {
-                        setMenuShown(menuShown == MenuName.SETTINGS ? MenuName.NONE : MenuName.SETTINGS)
+                        setMenuShown(menuShown == MenuName.SETTINGS ? MenuName.NONE : MenuName.SETTINGS);
                     }}
                 >
                     <SettingsIcon color={"white"} dim={"50px"} filled={menuShown != MenuName.SETTINGS} />
@@ -65,7 +58,7 @@ export function ControlButtons(props: ControlButtonProps) {
                 <ControlButton
                     dim={"50px"}
                     onClick={() => {
-                        setMenuShown(menuShown == MenuName.LEADERBOARD ? MenuName.NONE : MenuName.LEADERBOARD)
+                        setMenuShown(menuShown == MenuName.LEADERBOARD ? MenuName.NONE : MenuName.LEADERBOARD);
                     }}
                 >
                     <ViewListIcon color={"white"} dim={"50px"} filled={menuShown != MenuName.LEADERBOARD} />

--- a/src/components/ControlButtons.tsx
+++ b/src/components/ControlButtons.tsx
@@ -15,8 +15,6 @@ interface ControlButtonProps {
     setLeaderboardShown: (shouldShow: boolean) => void;
     settingsMenuShown: boolean;
     setSettingsMenuShown: (shouldShow: boolean) => void;
-    starLightState: boolean;
-    updateStarLight: (starLight: boolean) => void;
 }
 
 export function ControlButtons(props: ControlButtonProps) {
@@ -31,63 +29,51 @@ export function ControlButtons(props: ControlButtonProps) {
     } = props;
     return (
         <ButtonContainer>
-            <Dashboard>
-                <ButtonRow>
+            <ButtonRow>
+                <ControlButton
+                    dim={"50px"}
+                    onClick={() => {
+                        setSettingsMenuShown(!settingsMenuShown);
+                    }}
+                >
+                    <SettingsIcon color={"white"} dim={"50px"} filled={!settingsMenuShown} />
+                </ControlButton>
+                {pausedState ? (
                     <ControlButton
                         dim={"50px"}
                         onClick={() => {
-                            setSettingsMenuShown(!settingsMenuShown);
+                            updatePaused(false);
                         }}
                     >
-                        <SettingsIcon color={"white"} dim={"50px"} filled={!settingsMenuShown} />
+                        <PlayIcon color={"white"} dim={"50px"} filled={true} />
                     </ControlButton>
-                    {pausedState ? (
-                        <ControlButton
-                            dim={"50px"}
-                            onClick={() => {
-                                updatePaused(false);
-                            }}
-                        >
-                            <PlayIcon color={"white"} dim={"50px"} filled={true} />
-                        </ControlButton>
-                    ) : (
-                        <ControlButton
-                            dim={"50px"}
-                            onClick={() => {
-                                updatePaused(true);
-                            }}
-                        >
-                            <PauseIcon color={"white"} dim={"50px"} filled={true} />
-                        </ControlButton>
-                    )}
+                ) : (
                     <ControlButton
                         dim={"50px"}
                         onClick={() => {
-                            resetSim.current = true;
+                            updatePaused(true);
                         }}
                     >
-                        <RestartIcon color={"white"} dim={"50px"} filled={true} />
+                        <PauseIcon color={"white"} dim={"50px"} filled={true} />
                     </ControlButton>
-                    <ControlButton
-                        dim={"50px"}
-                        onClick={() => {
-                            setLeaderboardShown(!leaderboardShown);
-                        }}
-                    >
-                        <ViewListIcon color={"white"} dim={"50px"} filled={!leaderboardShown} />
-                    </ControlButton>
+                )}
+                <ControlButton
+                    dim={"50px"}
+                    onClick={() => {
+                        resetSim.current = true;
+                    }}
+                >
+                    <RestartIcon color={"white"} dim={"50px"} filled={true} />
+                </ControlButton>
+                <ControlButton
+                    dim={"50px"}
+                    onClick={() => {
+                        setLeaderboardShown(!leaderboardShown);
+                    }}
+                >
+                    <ViewListIcon color={"white"} dim={"50px"} filled={!leaderboardShown} />
+                </ControlButton>
                 </ButtonRow>
-                <ButtonRow>
-                    <ControlButton
-                        dim={"40px"}
-                        onClick={() => {
-                            props.updateStarLight(!props.starLightState);
-                        }}
-                    >
-                        <SunnyIcon color={"white"} dim={"40px"} filled={true} />
-                    </ControlButton>
-                </ButtonRow>
-            </Dashboard>
         </ButtonContainer>
     );
 }
@@ -96,24 +82,16 @@ const ButtonContainer = styled.div`
     grid-area: buttons;
     margin-left: auto;
     margin-right: auto;
+    padding-top: 10px;
+    padding-bottom: 10px;
 
     display: flex;
-    flex-direction: column;
-    justify-content: flex-end;
-    align-items: center;
-
-    width: 320px;
-    height: 100%;
-`;
-
-const Dashboard = styled.div`
-    display: flex;
-    height: min-content;
-    flex-direction: column;
+    flex-direction: row;
     justify-content: center;
     align-items: center;
-    gap: 10px;
-    margin-bottom: 20px;
+    
+    width: 320px;
+    height: 100%;
 `;
 
 const ButtonRow = styled.div`

--- a/src/components/ControlButtons.tsx
+++ b/src/components/ControlButtons.tsx
@@ -5,7 +5,6 @@ import { RestartIcon } from "../assets/icons/RestartIcon";
 import { PlayIcon } from "../assets/icons/PlayIcon";
 import { SettingsIcon } from "../assets/icons/SettingsIcon";
 import { ViewListIcon } from "../assets/icons/ViewListIcon";
-import { SunnyIcon } from "../assets/icons/SunnyIcon";
 
 interface ControlButtonProps {
     pausedState: boolean;
@@ -73,7 +72,7 @@ export function ControlButtons(props: ControlButtonProps) {
                 >
                     <ViewListIcon color={"white"} dim={"50px"} filled={!leaderboardShown} />
                 </ControlButton>
-                </ButtonRow>
+            </ButtonRow>
         </ButtonContainer>
     );
 }
@@ -89,7 +88,7 @@ const ButtonContainer = styled.div`
     flex-direction: row;
     justify-content: center;
     align-items: center;
-    
+
     width: 320px;
     height: 100%;
 `;

--- a/src/components/ControlButtons.tsx
+++ b/src/components/ControlButtons.tsx
@@ -5,15 +5,15 @@ import { RestartIcon } from "../assets/icons/RestartIcon";
 import { PlayIcon } from "../assets/icons/PlayIcon";
 import { SettingsIcon } from "../assets/icons/SettingsIcon";
 import { ViewListIcon } from "../assets/icons/ViewListIcon";
+import { MenuName } from "../lib/defines/MenuName";
+
 
 interface ControlButtonProps {
     pausedState: boolean;
     updatePaused: (shouldPause: boolean) => void;
     resetSim: React.RefObject<boolean>;
-    leaderboardShown: boolean;
-    setLeaderboardShown: (shouldShow: boolean) => void;
-    settingsMenuShown: boolean;
-    setSettingsMenuShown: (shouldShow: boolean) => void;
+    menuShown: MenuName;
+    setMenuShown: React.Dispatch<React.SetStateAction<MenuName>>;
 }
 
 export function ControlButtons(props: ControlButtonProps) {
@@ -21,10 +21,8 @@ export function ControlButtons(props: ControlButtonProps) {
         pausedState,
         updatePaused,
         resetSim,
-        leaderboardShown,
-        setLeaderboardShown,
-        settingsMenuShown,
-        setSettingsMenuShown,
+        menuShown,
+        setMenuShown
     } = props;
     return (
         <ButtonContainer>
@@ -32,10 +30,10 @@ export function ControlButtons(props: ControlButtonProps) {
                 <ControlButton
                     dim={"50px"}
                     onClick={() => {
-                        setSettingsMenuShown(!settingsMenuShown);
+                        setMenuShown(menuShown == MenuName.SETTINGS ? MenuName.NONE : MenuName.SETTINGS)
                     }}
                 >
-                    <SettingsIcon color={"white"} dim={"50px"} filled={!settingsMenuShown} />
+                    <SettingsIcon color={"white"} dim={"50px"} filled={menuShown != MenuName.SETTINGS} />
                 </ControlButton>
                 {pausedState ? (
                     <ControlButton
@@ -67,10 +65,10 @@ export function ControlButtons(props: ControlButtonProps) {
                 <ControlButton
                     dim={"50px"}
                     onClick={() => {
-                        setLeaderboardShown(!leaderboardShown);
+                        setMenuShown(menuShown == MenuName.LEADERBOARD ? MenuName.NONE : MenuName.LEADERBOARD)
                     }}
                 >
-                    <ViewListIcon color={"white"} dim={"50px"} filled={!leaderboardShown} />
+                    <ViewListIcon color={"white"} dim={"50px"} filled={menuShown != MenuName.LEADERBOARD} />
                 </ControlButton>
             </ButtonRow>
         </ButtonContainer>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,13 +10,13 @@ const Headerbar = styled.div`
 
     display: grid;
     grid-template-areas: "left center right";
-    grid-template-columns: 200px 1fr 200px;
+    grid-template-columns: 1fr 1fr 1fr;
     grid-template-rows: 1fr;
 
     border-bottom: 0.25rem solid ${color_offwhite};
 
     @media (max-width: ${phone}) {
-        height: 30px;
+        height: 45px;
     }
 
     a {
@@ -45,7 +45,7 @@ const Headerbar = styled.div`
 
         @media (max-width: ${phone}) {
             margin-left: 0px;
-            font-size: 0.95rem;
+            font-size: 0.75rem;
         }
     }
 `;
@@ -71,6 +71,9 @@ const Center = styled.div`
         border: none;
         padding: 0;
         margin: 0;
+        @media (max-width: ${tablet}) {
+            font-size: 1.25rem;
+        }
     }
 `;
 

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -99,7 +99,7 @@ const LeaderboardStyle = styled.div`
     margin-left: auto;
     margin-right: auto;
     width: 320px;
-    height: 200px;
+    height: 100%;
 
     background-color: black;
     overflow-y: auto;

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -4,12 +4,21 @@ import React from "react";
 interface SettingsMenuProps {
     debugStatsShown: boolean;
     setDebugStatsShown: React.Dispatch<React.SetStateAction<boolean>>;
+    starLightState: boolean;
+    updateStarLight: (starLight: boolean) => void;
 }
 
 export function SettingsMenu(props: SettingsMenuProps) {
-    const { debugStatsShown, setDebugStatsShown } = props;
+    const { debugStatsShown, setDebugStatsShown, starLightState, updateStarLight } = props;
     return (
         <SettingsStyle>
+            <button
+                onClick={() => {
+                    updateStarLight(!starLightState);
+                }}
+            >
+                {starLightState ? "Disable Star Light" : "Enable Star Light"}
+            </button>
             <button
                 onClick={() => {
                     setDebugStatsShown(!debugStatsShown);

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -29,7 +29,7 @@ const SettingsStyle = styled.div`
     align-items: center;
     padding: 5px;
 
-    height: 150px;
+    height: 100%;
     width: 320px;
     color: white;
     background-color: #202020;

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -17,6 +17,8 @@ const SettingsStyle = styled.div`
     background-color: #202020;
     border: 2px solid white;
 
+    z-index: 3;
+
     margin-left: auto;
     margin-right: auto;
 `;

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -1,7 +1,24 @@
 import styled from "@emotion/styled";
+import React from "react";
 
-export function SettingsMenu() {
-    return <SettingsStyle>Settings coming soon!</SettingsStyle>;
+interface SettingsMenuProps {
+    debugStatsShown: boolean;
+    setDebugStatsShown: React.Dispatch<React.SetStateAction<boolean>>;
+}
+
+export function SettingsMenu(props: SettingsMenuProps) {
+    const { debugStatsShown, setDebugStatsShown } = props;
+    return (
+        <SettingsStyle>
+            <button
+                onClick={() => {
+                    setDebugStatsShown(!debugStatsShown);
+                }}
+            >
+                {debugStatsShown ? "Hide Debug Stats" : "Show Debug Stats"}
+            </button>
+        </SettingsStyle>
+    );
 }
 
 const SettingsStyle = styled.div`
@@ -10,6 +27,7 @@ const SettingsStyle = styled.div`
     display: flex;
     flex-direction: column;
     align-items: center;
+    padding: 5px;
 
     height: 150px;
     width: 320px;

--- a/src/lib/defines/MenuName.tsx
+++ b/src/lib/defines/MenuName.tsx
@@ -1,0 +1,5 @@
+export enum MenuName {
+    NONE = "none",
+    LEADERBOARD = "leaderboard",
+    SETTINGS = "settings",
+}


### PR DESCRIPTION
The website is far more mobile friendly with this update:

- Application no longer exceeds the width and height of the screen on mobile devices
- Simulation control buttons simplified into a single row
- Rudimentary settings menu with two buttons (show debug, and star lighting)
- All menus have been moved closer to the buttons (more user-friendly)
- Settings and Leaderboard menus now close each other when opened

All menus are still quite ugly, but it should be vastly more functional on mobile now.