### PR TITLE
fix: 100vw and 100vh -> 100%

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,8 +30,8 @@ const Backdrop = styled.div`
 
 const SimScreen = styled.div`
     position: absolute;
-    height: 100vh;
-    width: 100vw;
+    height: 100%;
+    width: 100%;
     z-index: 0;
 `;
 


### PR DESCRIPTION
There is an issue on mobile where the app will  scroll slightly up and down vertically. I seem to recall this being an issue with the height of a component being set to 100vh. The android browser bar itself has a height of N pixels, so when you set a component to 100vh, the total height of the app is 100vh + N px, causing a scroll. I'm going to attempt to fix this by setting height to 100% instead.