### PR TITLE
Fixing unwanted page refreshes

### DIFF
--- a/src/hooks/useMouseControls.tsx
+++ b/src/hooks/useMouseControls.tsx
@@ -54,43 +54,5 @@ export function useMouseControls(cameraRef: React.RefObject<Camera>, cameraSensi
         lastMousePosition.current = null;
     };
 
-    /*
-        Touch Controls
-    */
-    const handleTouchStart = (event: React.TouchEvent<HTMLCanvasElement>) => {
-        isDragging.current = true;
-        const touch = event.touches[0];
-        const rect = event.currentTarget.getBoundingClientRect();
-        lastMousePosition.current = {
-            x: touch.clientX - rect.left,
-            y: touch.clientY - rect.top,
-        };
-    };
-
-    const handleTouchMove = (event: React.TouchEvent<HTMLCanvasElement>) => {
-        if (!isDragging.current || !lastMousePosition.current) return;
-
-        const touch = event.touches[0];
-        const rect = event.currentTarget.getBoundingClientRect();
-        const currentMousePosition = {
-            x: touch.clientX - rect.left,
-            y: touch.clientY - rect.top,
-        };
-
-        const deltaX = currentMousePosition.x - lastMousePosition.current.x;
-        const deltaY = currentMousePosition.y - lastMousePosition.current.y;
-
-        cameraRef.current!.yaw -= deltaX * cameraSensitivity;
-        cameraRef.current!.pitch -= deltaY * cameraSensitivity;
-
-        // Clamp pitch between -90 and 90
-        cameraRef.current!.pitch = Math.max(
-            Math.min(cameraRef.current!.pitch, Math.PI / 2 - 0.001),
-            -Math.PI / 2 + 0.001,
-        );
-
-        lastMousePosition.current = currentMousePosition;
-    };
-
-    return { handleMouseWheel, handleMouseDown, handleMouseMove, handleMouseUp, handleTouchStart, handleTouchMove };
+    return { handleMouseWheel, handleMouseDown, handleMouseMove, handleMouseUp};
 }

--- a/src/hooks/useMouseControls.tsx
+++ b/src/hooks/useMouseControls.tsx
@@ -54,5 +54,5 @@ export function useMouseControls(cameraRef: React.RefObject<Camera>, cameraSensi
         lastMousePosition.current = null;
     };
 
-    return { handleMouseWheel, handleMouseDown, handleMouseMove, handleMouseUp};
+    return { handleMouseWheel, handleMouseDown, handleMouseMove, handleMouseUp };
 }

--- a/src/hooks/useTouchControls.tsx
+++ b/src/hooks/useTouchControls.tsx
@@ -19,6 +19,8 @@ export function useTouchControls(cameraRef: React.RefObject<Camera>, cameraSensi
     };
 
     const handleTouchMove = (event: React.TouchEvent<HTMLCanvasElement>) => {
+        // Stop pull-down refresh from happening
+        event.preventDefault()
         if (!isDragging.current || !lastTouchPosition.current) return;
 
         const touch = event.touches[0];

--- a/src/hooks/useTouchControls.tsx
+++ b/src/hooks/useTouchControls.tsx
@@ -20,7 +20,7 @@ export function useTouchControls(cameraRef: React.RefObject<Camera>, cameraSensi
 
     const handleTouchMove = (event: React.TouchEvent<HTMLCanvasElement>) => {
         // Stop pull-down refresh from happening
-        event.preventDefault()
+        event.preventDefault();
         if (!isDragging.current || !lastTouchPosition.current) return;
 
         const touch = event.touches[0];


### PR DESCRIPTION
By default, the behavior on android is that when the user pulls down with touch, it refreshes the page. This has a very annoying interaction with the simulation - When the user tries to pan down, it also refreshes. Here, I try to prevent that from happening.