### PR TITLE
fix: touch-action none set to canvas

### DIFF
--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -378,4 +378,5 @@ const SimCanvas = styled.canvas`
     height: 100%;
     width: 100%;
     display: block;
+    touch-action: none;
 `;


### PR DESCRIPTION
Simply setting event to preventdefault on drag did not accomplish what I needed. I'm going to see if touch-action set to none will do it.