### PR TITLE
Fixed shader bloom squishing

### DIFF
--- a/src/assets/shaders/gaussianBlur/gaussianBlur.frag.glsl
+++ b/src/assets/shaders/gaussianBlur/gaussianBlur.frag.glsl
@@ -13,7 +13,6 @@ in highp vec2 TexCoords;
 uniform sampler2D uImage;
 uniform highp int uHorizontal; // 1 for horizontal blur, 0 for vertical blur
 uniform highp vec2 uViewportSize;
-uniform highp float uAspectRatio;
 
 highp float weight[5] = float[] (0.227027, 0.1945946, 0.1216216, 0.054054, 0.016216);
 

--- a/src/assets/shaders/gaussianBlur/gaussianBlur.frag.glsl
+++ b/src/assets/shaders/gaussianBlur/gaussianBlur.frag.glsl
@@ -12,24 +12,28 @@ in highp vec2 TexCoords;
 
 uniform sampler2D uImage;
 uniform highp int uHorizontal; // 1 for horizontal blur, 0 for vertical blur
+uniform highp vec2 uViewportSize;
 uniform highp float uAspectRatio;
 
 highp float weight[5] = float[] (0.227027, 0.1945946, 0.1216216, 0.054054, 0.016216);
 
 void main() {
-    highp vec2 tex_offset = 1.0 / vec2(textureSize(uImage, 0));
-    if (uHorizontal == 1) {
-        tex_offset.x /= uAspectRatio;
-    } else {
-        tex_offset.y /= uAspectRatio;
-    }
+    /*
+        The tutorial calls for tex_offset = 1.0 / vec2(textureSize(uImage, 0).
+        This works for them, because the resolution of their canvas is the same as their screen size.
+        The resolution of my canvas is independent from the screen size - And my texture sizes are set to the canvas size.
+        This resulted in an uneven gaussian blur, and by extension, a squashed-looking bloom.
+        Setting the texel offset to be based on the viewport size allows for even blurring.
+    */
+    highp vec2 tex_offset = 1.0 / uViewportSize; // Texture coordinates offset
+
     highp vec3 result = texture(uImage, TexCoords).rgb * weight[0];
     if (uHorizontal == 1) {
         for (int i = 1; i < 5; ++i) {
             result += texture(uImage, TexCoords + vec2(tex_offset.x * float(i), 0.0)).rgb * weight[i];
             result += texture(uImage, TexCoords - vec2(tex_offset.x * float(i), 0.0)).rgb * weight[i];
         }
-    } else {
+    } else {  
         for (int i = 1; i < 5; ++i) {
             result += texture(uImage, TexCoords + vec2(0.0, tex_offset.y * float(i))).rgb * weight[i];
             result += texture(uImage, TexCoords - vec2(0.0, tex_offset.y * float(i))).rgb * weight[i];

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -258,7 +258,6 @@ export function Sim(props: SimProps) {
                 uniformLocations: {
                     uImage: gl.getUniformLocation(gaussianBlurShaderProgram, "uImage"),
                     uHorizontal: gl.getUniformLocation(gaussianBlurShaderProgram, "uHorizontal"),
-                    uAspectRatio: gl.getUniformLocation(gaussianBlurShaderProgram, "uAspectRatio"),
                     uViewportSize: gl.getUniformLocation(gaussianBlurShaderProgram, "uViewportSize"),
                 },
             };
@@ -705,7 +704,6 @@ export function Sim(props: SimProps) {
                             gl.bindFramebuffer(gl.FRAMEBUFFER, blurFrameBuffer[horizontal]);
                             // Set horizontal int to horizontal
                             gl.uniform1i(gaussianBlurProgramInfo.uniformLocations.uHorizontal, horizontal);
-                            gl.uniform1f(gaussianBlurProgramInfo.uniformLocations.uAspectRatio, aspect);
                             gl.uniform2fv(gaussianBlurProgramInfo.uniformLocations.uViewportSize, [
                                 canvas.clientWidth,
                                 canvas.clientHeight,

--- a/src/lib/webGL/shaderPrograms.tsx
+++ b/src/lib/webGL/shaderPrograms.tsx
@@ -49,7 +49,6 @@ export interface GaussianBlurProgramInfo {
     uniformLocations: {
         uImage: WebGLUniformLocation | null;
         uHorizontal: WebGLUniformLocation | null;
-        uAspectRatio: WebGLUniformLocation | null;
         uViewportSize: WebGLUniformLocation | null;
     };
 }

--- a/src/lib/webGL/shaderPrograms.tsx
+++ b/src/lib/webGL/shaderPrograms.tsx
@@ -50,6 +50,7 @@ export interface GaussianBlurProgramInfo {
         uImage: WebGLUniformLocation | null;
         uHorizontal: WebGLUniformLocation | null;
         uAspectRatio: WebGLUniformLocation | null;
+        uViewportSize: WebGLUniformLocation | null;
     };
 }
 


### PR DESCRIPTION
The tutorial I was following set its gaussian blur based on its texture size. This was fine for them, because its texture size was the same as its program resolution and the same as its viewport size. However, my canvas resolution is independent from the viewport size, which was causing the blur to look distorted. By adjusting the blur based on viewport size instead of canvas resolution, it looks consistent across all devices.