### PR TITLE
New Information and Information Refactor

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,7 @@ export function App() {
     // Display the bodies inside of the leaderboard menu. Sorted by order of mass by universe class.
     const [leaderboardBodies, setLeaderboardBodies] = useState<Array<LeaderboardBody>>([]);
 
-    const showDebug = useSelector((state: RootState) => state.debugInfo.showDebug);
+    const showDebug = useSelector((state: RootState) => state.information.showDebug);
     const menuShown = useSelector((state: RootState) => state.controls.menuShown);
 
     return (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,7 @@ export function App() {
     // Display the bodies inside of the leaderboard menu. Sorted by order of mass by universe class.
     const [leaderboardBodies, setLeaderboardBodies] = useState<Array<LeaderboardBody>>([]);
 
-    const showDebug = useSelector((state: RootState) => state.information.showDebug);
+    const showDebug = useSelector((state: RootState) => state.controls.showDebug);
     const menuShown = useSelector((state: RootState) => state.controls.menuShown);
 
     return (

--- a/src/components/DebugStats.tsx
+++ b/src/components/DebugStats.tsx
@@ -3,7 +3,7 @@ import { useSelector } from "react-redux";
 import { RootState } from "../redux/store";
 
 export function DebugStats() {
-    const debug = useSelector((state: RootState) => state.debugInfo);
+    const debug = useSelector((state: RootState) => state.information);
 
     return (
         <DebugStatsStyle>

--- a/src/components/InfoBox.tsx
+++ b/src/components/InfoBox.tsx
@@ -14,8 +14,9 @@ export function InfoBox() {
 
     return (
         <InfoBoxStyle>
+            <div className="tp">Year</div>
             <div className="lt" />
-            <div className="text">Following: {bodyFollowed != -1 ? "B-" + bodyFollowed : "None"}</div>
+            <div className="ct">Following: {bodyFollowed != -1 ? "B-" + bodyFollowed : "None"}</div>
             <div className="rt">
                 {bodyFollowed != -1 ? (
                     <button
@@ -51,9 +52,9 @@ const InfoBoxStyle = styled.div`
 
     display: grid;
 
-    grid-template-areas: "left center right";
+    grid-template-areas: "top top top" "left center right";
     grid-template-columns: 1fr 150px 1fr;
-    grid-template-rows: 1fr;
+    grid-template-rows: 1fr 1fr;
 
     font-size: 1.2rem;
 
@@ -65,7 +66,14 @@ const InfoBoxStyle = styled.div`
         min-width: 85px;
     }
 
-    div.text {
+    div.tp {
+        grid-area: top;
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+    }
+
+    div.ct {
         grid-area: center;
         display: flex;
         justify-content: center;

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -6,15 +6,13 @@ import { useState } from "react";
 export function SettingsMenu() {
     const graphicsSettings = useSelector((state: RootState) => state.graphicsSettings);
     const universeSettings = useSelector((state: RootState) => state.universeSettings);
-    const showDebug = useSelector((state: RootState) => state.debugInfo.showDebug);
-    const showCircles = useSelector((state: RootState) => state.debugInfo.showCircles);
-    const circleType = useSelector((state: RootState) => state.debugInfo.circleType);
+    const showDebug = useSelector((state: RootState) => state.information.showDebug);
+    const showCircles = useSelector((state: RootState) => state.information.showCircles);
+    const circleType = useSelector((state: RootState) => state.information.circleType);
     const dispatch = useDispatch();
 
     const [seed, setSeed] = useState(universeSettings.seed);
     const [numBodies, setNumBodies] = useState(universeSettings.numBodies);
-
-    console.log(universeSettings.seed);
 
     return (
         <SettingsStyle>
@@ -22,14 +20,14 @@ export function SettingsMenu() {
             <div>
                 <button
                     onClick={() => {
-                        dispatch({ type: "debugInfo/toggleDebug" });
+                        dispatch({ type: "information/toggleDebug" });
                     }}
                 >
                     {showDebug ? "Hide Debug" : "Show Debug"}
                 </button>
                 <button
                     onClick={() => {
-                        dispatch({ type: "debugInfo/toggleCircles" });
+                        dispatch({ type: "information/toggleCircles" });
                     }}
                 >
                     {showCircles ? "Hide Circles" : "Show Circles"}
@@ -37,7 +35,7 @@ export function SettingsMenu() {
             </div>
             <button
                 onClick={() => {
-                    dispatch({ type: "debugInfo/toggleCircleType" });
+                    dispatch({ type: "information/toggleCircleType" });
                 }}
             >
                 {circleType === "incremental" ? "Incremental Circles" : "Solar Circles"}

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -2,12 +2,12 @@ import styled from "@emotion/styled";
 import { useSelector, useDispatch } from "react-redux";
 import { RootState } from "../redux/store";
 import { useState } from "react";
+import { CircleType } from "../redux/controlsSlice";
 
 export function SettingsMenu() {
     const graphicsSettings = useSelector((state: RootState) => state.graphicsSettings);
     const universeSettings = useSelector((state: RootState) => state.universeSettings);
     const showDebug = useSelector((state: RootState) => state.controls.showDebug);
-    const showCircles = useSelector((state: RootState) => state.controls.showCircles);
     const circleType = useSelector((state: RootState) => state.controls.circleType);
     const dispatch = useDispatch();
 
@@ -25,21 +25,34 @@ export function SettingsMenu() {
                 >
                     {showDebug ? "Hide Debug" : "Show Debug"}
                 </button>
-                <button
-                    onClick={() => {
-                        dispatch({ type: "controls/toggleCircles" });
-                    }}
-                >
-                    {showCircles ? "Hide Circles" : "Show Circles"}
-                </button>
             </div>
-            <button
-                onClick={() => {
-                    dispatch({ type: "controls/toggleCircleType" });
-                }}
-            >
-                {circleType === "incremental" ? "Incremental Circles" : "Solar Circles"}
-            </button>
+            <label>Circles:</label>
+            <div>
+                <input
+                    type="radio"
+                    id="none"
+                    name="circles"
+                    checked={circleType === CircleType.NONE}
+                    onChange={() => dispatch({ type: "controls/setCircleType", payload: CircleType.NONE })}
+                />
+                <label htmlFor="none">None</label>
+                <input
+                    type="radio"
+                    id="incremental"
+                    name="circles"
+                    checked={circleType === CircleType.INCREMENTAL}
+                    onChange={() => dispatch({ type: "controls/setCircleType", payload: CircleType.INCREMENTAL })}
+                />
+                <label htmlFor="incremental">Incremental</label>
+                <input
+                    type="radio"
+                    id="solar"
+                    name="circles"
+                    checked={circleType === CircleType.SOLAR}
+                    onChange={() => dispatch({ type: "controls/setCircleType", payload: CircleType.SOLAR })}
+                />
+                <label htmlFor="solar">Solar</label>
+            </div>
             Graphics
             <button
                 onClick={() => {

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -6,9 +6,9 @@ import { useState } from "react";
 export function SettingsMenu() {
     const graphicsSettings = useSelector((state: RootState) => state.graphicsSettings);
     const universeSettings = useSelector((state: RootState) => state.universeSettings);
-    const showDebug = useSelector((state: RootState) => state.information.showDebug);
-    const showCircles = useSelector((state: RootState) => state.information.showCircles);
-    const circleType = useSelector((state: RootState) => state.information.circleType);
+    const showDebug = useSelector((state: RootState) => state.controls.showDebug);
+    const showCircles = useSelector((state: RootState) => state.controls.showCircles);
+    const circleType = useSelector((state: RootState) => state.controls.circleType);
     const dispatch = useDispatch();
 
     const [seed, setSeed] = useState(universeSettings.seed);
@@ -20,14 +20,14 @@ export function SettingsMenu() {
             <div>
                 <button
                     onClick={() => {
-                        dispatch({ type: "information/toggleDebug" });
+                        dispatch({ type: "controls/toggleDebug" });
                     }}
                 >
                     {showDebug ? "Hide Debug" : "Show Debug"}
                 </button>
                 <button
                     onClick={() => {
-                        dispatch({ type: "information/toggleCircles" });
+                        dispatch({ type: "controls/toggleCircles" });
                     }}
                 >
                     {showCircles ? "Hide Circles" : "Show Circles"}
@@ -35,7 +35,7 @@ export function SettingsMenu() {
             </div>
             <button
                 onClick={() => {
-                    dispatch({ type: "information/toggleCircleType" });
+                    dispatch({ type: "controls/toggleCircleType" });
                 }}
             >
                 {circleType === "incremental" ? "Incremental Circles" : "Solar Circles"}

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -42,7 +42,7 @@ import { LeaderboardBody } from "./Leaderboard";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../redux/store";
 import { getCirclePositions } from "../lib/webGL/shapes";
-import { CircleType } from "../redux/debugSlice";
+import { CircleType } from "../redux/informationSlice";
 import { SolarSystemDistanceAU } from "../lib/defines/solarSystem";
 
 const ticksPerSecond = 60;
@@ -80,13 +80,13 @@ export function Sim(props: SimProps) {
         states or selectors. To work around this, I convert them into refs.
     */
     // User-set debug settings
-    const showCircles = useSelector((state: RootState) => state.debugInfo.showCircles);
+    const showCircles = useSelector((state: RootState) => state.information.showCircles);
     const showCirclesRef = useRef(showCircles);
     useEffect(() => {
         showCirclesRef.current = showCircles;
     }, [showCircles]);
 
-    const circleType = useSelector((state: RootState) => state.debugInfo.circleType);
+    const circleType = useSelector((state: RootState) => state.information.circleType);
     const circleTypeRef = useRef(circleType);
     useEffect(() => {
         circleTypeRef.current = circleType;
@@ -121,8 +121,8 @@ export function Sim(props: SimProps) {
         cameraRef.current.setAll(0, 0, 0, 0, 0, -20);
         dispatch({ type: "controls/unsetBodyFollowed", payload: 0 });
         setLeaderboardBodies(universe.current.getActiveBodies(-1));
-        dispatch({ type: "debugInfo/setNumActiveBodies", payload: universe.current.numActive });
-        dispatch({ type: "debugInfo/setNumStars", payload: universe.current.getNumStars() });
+        dispatch({ type: "information/setNumActiveBodies", payload: universe.current.numActive });
+        dispatch({ type: "information/setNumStars", payload: universe.current.getNumStars() });
     }, [settings]);
 
     useEffect(() => {
@@ -130,8 +130,8 @@ export function Sim(props: SimProps) {
         dispatch({ type: "controls/unsetBodyFollowed", payload: 0 });
         universe.current.reset();
         setLeaderboardBodies(universe.current.getActiveBodies(-1));
-        dispatch({ type: "debugInfo/setNumActiveBodies", payload: universe.current.numActive });
-        dispatch({ type: "debugInfo/setNumStars", payload: universe.current.getNumStars() });
+        dispatch({ type: "information/setNumActiveBodies", payload: universe.current.numActive });
+        dispatch({ type: "information/setNumStars", payload: universe.current.getNumStars() });
     }, [resetSim]);
 
     useEffect(() => {
@@ -165,20 +165,20 @@ export function Sim(props: SimProps) {
             setLeaderboardBodies(universe.current.getActiveBodies(bodyFollowed));
 
             // Set unchanging webGL debug text
-            dispatch({ type: "debugInfo/setNumActiveBodies", payload: universe.current.numActive });
+            dispatch({ type: "information/setNumActiveBodies", payload: universe.current.numActive });
             dispatch({
-                type: "debugInfo/setMaxVertexUniformVectors",
+                type: "information/setMaxVertexUniformVectors",
                 payload: gl.getParameter(gl.MAX_VERTEX_UNIFORM_VECTORS),
             });
             dispatch({
-                type: "debugInfo/setMaxFragmentUniformVectors",
+                type: "information/setMaxFragmentUniformVectors",
                 payload: gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS),
             });
             dispatch({
-                type: "debugInfo/setMaxUniformBufferBindingPoints",
+                type: "information/setMaxUniformBufferBindingPoints",
                 payload: gl.getParameter(gl.MAX_UNIFORM_BUFFER_BINDINGS),
             });
-            dispatch({ type: "debugInfo/setMaxSamples", payload: gl.getParameter(gl.MAX_SAMPLES) });
+            dispatch({ type: "information/setMaxSamples", payload: gl.getParameter(gl.MAX_SAMPLES) });
             let maxBufferBitDepth = "RGBA8";
             if (gl.getExtension("EXT_color_buffer_float")) {
                 maxBufferBitDepth = "RGBA32F";
@@ -186,7 +186,7 @@ export function Sim(props: SimProps) {
                 maxBufferBitDepth = "RGBA16F";
             }
             dispatch({
-                type: "debugInfo/setMaxBufferBitDepth",
+                type: "information/setMaxBufferBitDepth",
                 payload: maxBufferBitDepth,
             });
 
@@ -514,16 +514,16 @@ export function Sim(props: SimProps) {
                 uiAccumulatedTime += deltaTime;
                 if (uiAccumulatedTime >= uiThrottleTime) {
                     setLeaderboardBodies(universe.current.getActiveBodies(bodyFollowedRef.current));
-                    dispatch({ type: "debugInfo/setNumActiveBodies", payload: universe.current.numActive });
-                    dispatch({ type: "debugInfo/setNumStars", payload: universe.current.getNumStars() });
+                    dispatch({ type: "information/setNumActiveBodies", payload: universe.current.numActive });
+                    dispatch({ type: "information/setNumStars", payload: universe.current.getNumStars() });
                     dispatch({
-                        type: "debugInfo/setNumActiveUniforms",
+                        type: "information/setNumActiveUniforms",
                         payload: starLightRef.current
                             ? gl.getProgramParameter(starlightProgramInfo.program, gl.ACTIVE_UNIFORMS)
                             : gl.getProgramParameter(camlightProgramInfo.program, gl.ACTIVE_UNIFORMS),
                     });
                     dispatch({
-                        type: "debugInfo/setNumActiveUniformVectors",
+                        type: "information/setNumActiveUniformVectors",
                         payload: starLightRef.current
                             ? calculateUniformVectors(gl, starlightProgramInfo.program)
                             : calculateUniformVectors(gl, camlightProgramInfo.program),

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -80,12 +80,6 @@ export function Sim(props: SimProps) {
         states or selectors. To work around this, I convert them into refs.
     */
     // User-set debug settings
-    const showCircles = useSelector((state: RootState) => state.controls.showCircles);
-    const showCirclesRef = useRef(showCircles);
-    useEffect(() => {
-        showCirclesRef.current = showCircles;
-    }, [showCircles]);
-
     const circleType = useSelector((state: RootState) => state.controls.circleType);
     const circleTypeRef = useRef(circleType);
     useEffect(() => {
@@ -563,7 +557,7 @@ export function Sim(props: SimProps) {
                 /*
                     Draw debug circles
                 */
-                if (showCirclesRef.current) {
+                if (!(circleTypeRef.current == CircleType.NONE)) {
                     gl.useProgram(simpleProgramInfo.program);
                     gl.bindBuffer(gl.ARRAY_BUFFER, circleBuffers.position);
                     setPositionAttribute(gl, circleBuffers, simpleProgramInfo.attribLocations);

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -42,8 +42,8 @@ import { LeaderboardBody } from "./Leaderboard";
 import { useDispatch, useSelector } from "react-redux";
 import { RootState } from "../redux/store";
 import { getCirclePositions } from "../lib/webGL/shapes";
-import { CircleType } from "../redux/informationSlice";
 import { SolarSystemDistanceAU } from "../lib/defines/solarSystem";
+import { CircleType } from "../redux/controlsSlice";
 
 const ticksPerSecond = 60;
 const secondsPerTick = 1 / ticksPerSecond;
@@ -80,13 +80,13 @@ export function Sim(props: SimProps) {
         states or selectors. To work around this, I convert them into refs.
     */
     // User-set debug settings
-    const showCircles = useSelector((state: RootState) => state.information.showCircles);
+    const showCircles = useSelector((state: RootState) => state.controls.showCircles);
     const showCirclesRef = useRef(showCircles);
     useEffect(() => {
         showCirclesRef.current = showCircles;
     }, [showCircles]);
 
-    const circleType = useSelector((state: RootState) => state.information.circleType);
+    const circleType = useSelector((state: RootState) => state.controls.circleType);
     const circleTypeRef = useRef(circleType);
     useEffect(() => {
         circleTypeRef.current = circleType;

--- a/src/redux/controlsSlice.ts
+++ b/src/redux/controlsSlice.ts
@@ -6,12 +6,20 @@ export enum MenuName {
     SETTINGS = "settings",
 }
 
+export enum CircleType {
+    INCREMENTAL = "incremental",
+    SOLAR = "solar",
+}
+
 export interface ControlsState {
     paused: boolean;
     resetSim: number;
     resetCam: number;
     menuShown: MenuName;
     bodyFollowed: number;
+    showDebug: boolean;
+    showCircles: boolean;
+    circleType: CircleType;
 }
 
 const initialState: ControlsState = {
@@ -20,6 +28,9 @@ const initialState: ControlsState = {
     resetCam: 0,
     bodyFollowed: -1,
     menuShown: MenuName.NONE,
+    showDebug: false,
+    showCircles: false,
+    circleType: CircleType.INCREMENTAL,
 };
 
 export const controlSlice = createSlice({
@@ -47,6 +58,15 @@ export const controlSlice = createSlice({
         },
         hideMenu: (state) => {
             state.menuShown = MenuName.NONE;
+        },
+        toggleDebug: (state) => {
+            state.showDebug = !state.showDebug;
+        },
+        toggleCircles: (state) => {
+            state.showCircles = !state.showCircles;
+        },
+        toggleCircleType: (state) => {
+            state.circleType = state.circleType === CircleType.INCREMENTAL ? CircleType.SOLAR : CircleType.INCREMENTAL;
         },
     },
 });

--- a/src/redux/controlsSlice.ts
+++ b/src/redux/controlsSlice.ts
@@ -1,14 +1,14 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 export enum MenuName {
-    NONE = "none",
-    LEADERBOARD = "leaderboard",
-    SETTINGS = "settings",
+    NONE,
+    LEADERBOARD,
+    SETTINGS,
 }
 
 export enum CircleType {
-    INCREMENTAL = "incremental",
-    SOLAR = "solar",
+    INCREMENTAL,
+    SOLAR,
 }
 
 export interface ControlsState {

--- a/src/redux/controlsSlice.ts
+++ b/src/redux/controlsSlice.ts
@@ -7,6 +7,7 @@ export enum MenuName {
 }
 
 export enum CircleType {
+    NONE,
     INCREMENTAL,
     SOLAR,
 }
@@ -18,7 +19,6 @@ export interface ControlsState {
     menuShown: MenuName;
     bodyFollowed: number;
     showDebug: boolean;
-    showCircles: boolean;
     circleType: CircleType;
 }
 
@@ -29,8 +29,7 @@ const initialState: ControlsState = {
     bodyFollowed: -1,
     menuShown: MenuName.NONE,
     showDebug: false,
-    showCircles: false,
-    circleType: CircleType.INCREMENTAL,
+    circleType: CircleType.NONE,
 };
 
 export const controlSlice = createSlice({
@@ -62,11 +61,8 @@ export const controlSlice = createSlice({
         toggleDebug: (state) => {
             state.showDebug = !state.showDebug;
         },
-        toggleCircles: (state) => {
-            state.showCircles = !state.showCircles;
-        },
-        toggleCircleType: (state) => {
-            state.circleType = state.circleType === CircleType.INCREMENTAL ? CircleType.SOLAR : CircleType.INCREMENTAL;
+        setCircleType: (state, action) => {
+            state.circleType = action.payload;
         },
     },
 });

--- a/src/redux/informationSlice.ts
+++ b/src/redux/informationSlice.ts
@@ -5,7 +5,7 @@ export enum CircleType {
     SOLAR = "solar",
 }
 
-export interface DebugStatsState {
+export interface InformationState {
     showDebug: boolean;
     showCircles: boolean;
     circleType: CircleType;
@@ -22,7 +22,7 @@ export interface DebugStatsState {
     numActiveUniformVectors: number;
 }
 
-const initialState: DebugStatsState = {
+const initialState: InformationState = {
     showDebug: false,
     showCircles: false,
     circleType: CircleType.INCREMENTAL,
@@ -37,8 +37,8 @@ const initialState: DebugStatsState = {
     numActiveUniformVectors: 0,
 };
 
-export const debugInfoSlice = createSlice({
-    name: "debugInfo",
+export const informationSlice = createSlice({
+    name: "information",
     initialState,
     reducers: {
         toggleDebug: (state) => {
@@ -80,4 +80,4 @@ export const debugInfoSlice = createSlice({
     },
 });
 
-export default debugInfoSlice.reducer;
+export default informationSlice.reducer;

--- a/src/redux/informationSlice.ts
+++ b/src/redux/informationSlice.ts
@@ -1,14 +1,6 @@
 import { createSlice } from "@reduxjs/toolkit";
 
-export enum CircleType {
-    INCREMENTAL = "incremental",
-    SOLAR = "solar",
-}
-
 export interface InformationState {
-    showDebug: boolean;
-    showCircles: boolean;
-    circleType: CircleType;
     // Universe debug variables
     numActiveBodies: number;
     numStars: number;
@@ -23,9 +15,6 @@ export interface InformationState {
 }
 
 const initialState: InformationState = {
-    showDebug: false,
-    showCircles: false,
-    circleType: CircleType.INCREMENTAL,
     numActiveBodies: 0,
     numStars: 0,
     maxVertexUniformVectors: 0,
@@ -41,15 +30,6 @@ export const informationSlice = createSlice({
     name: "information",
     initialState,
     reducers: {
-        toggleDebug: (state) => {
-            state.showDebug = !state.showDebug;
-        },
-        toggleCircles: (state) => {
-            state.showCircles = !state.showCircles;
-        },
-        toggleCircleType: (state) => {
-            state.circleType = state.circleType === CircleType.INCREMENTAL ? CircleType.SOLAR : CircleType.INCREMENTAL;
-        },
         setNumActiveBodies: (state, action) => {
             state.numActiveBodies = action.payload;
         },

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -2,14 +2,14 @@
 
 import { configureStore } from "@reduxjs/toolkit";
 import graphicsSettingsReducer from "./graphicsSettingsSlice";
-import debugInfoReducer from "./debugSlice";
+import informationReducer from "./informationSlice";
 import universeSettingsReducer from "./universeSettingsSlice";
 import controlsReducer from "./controlsSlice";
 
 export const store = configureStore({
     reducer: {
         controls: controlsReducer,
-        debugInfo: debugInfoReducer,
+        information: informationReducer,
         graphicsSettings: graphicsSettingsReducer,
         universeSettings: universeSettingsReducer,
     },


### PR DESCRIPTION
- Replaced the "DebugInfo" slice with a generic "Information" slice, intended to intake live simulation and debug info
- Moved debug menu toggling and circle controls into the "Controls" slice for consistency
- Small refactor of measurement circles (it used to be toggleable boolean and an enum with the name - now it's just an enum with an added "none" type)
- Added spot to show simulation time at the top