### PR TITLE
New debug menu entries

### DIFF
--- a/src/components/DebugStats.tsx
+++ b/src/components/DebugStats.tsx
@@ -16,8 +16,8 @@ export function DebugStats() {
             <div>Max Fragment Uniform Vectors: {debug.maxFragmentUniformVectors}</div>
             <div>Max Uniform Buffer Binding Points: {debug.maxUniformBufferBindingPoints}</div>
             <div>Max Samples: {debug.maxSamples}</div>
-            <div>RBGA32F Supported: {debug.rgba32fSupported}</div>
-            <div>RBGA16F Supported: {debug.rgba16fSupported}</div>
+            <div>RBGA32F Supported: {debug.rgba32fSupported ? "TRUE" : "FALSE"}</div>
+            <div>RBGA16F Supported: {debug.rgba16fSupported ? "TRUE" : "FALSE"}</div>
             <div>Active Uniforms: {debug.numActiveUniforms}</div>
             <div>Active Uniform Vectors: {debug.numActiveUniformVectors}</div>
         </DebugStatsStyle>

--- a/src/components/DebugStats.tsx
+++ b/src/components/DebugStats.tsx
@@ -15,8 +15,9 @@ export function DebugStats() {
             <div>Max Vertex Uniform Vectors: {debug.maxVertexUniformVectors}</div>
             <div>Max Fragment Uniform Vectors: {debug.maxFragmentUniformVectors}</div>
             <div>Max Uniform Buffer Binding Points: {debug.maxUniformBufferBindingPoints}</div>
-            <div>Max Antialiasing Samples: {debug.maxSamples}</div>
-            <div>Max Color Buffer Bit Depth: {debug.maxBufferBitDepth}</div>
+            <div>Max Samples: {debug.maxSamples}</div>
+            <div>RBGA32F Supported: {debug.rgba32fSupported}</div>
+            <div>RBGA16F Supported: {debug.rgba16fSupported}</div>
             <div>Active Uniforms: {debug.numActiveUniforms}</div>
             <div>Active Uniform Vectors: {debug.numActiveUniformVectors}</div>
         </DebugStatsStyle>

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -164,7 +164,6 @@ export function Sim(props: SimProps) {
                 type: "information/setMaxVertexUniformVectors",
                 payload: gl.getParameter(gl.MAX_VERTEX_UNIFORM_VECTORS),
             });
-            console.log(gl.getParameter(gl.MAX_VERTEX_UNIFORM_VECTORS));
             dispatch({
                 type: "information/setMaxFragmentUniformVectors",
                 payload: gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS),
@@ -368,10 +367,6 @@ export function Sim(props: SimProps) {
 
             const renderBufferFormat = extColorBufferHalfFloat ? gl.RGBA16F : gl.RGBA;
             const renderBufferType = extColorBufferHalfFloat ? gl.HALF_FLOAT : gl.UNSIGNED_BYTE;
-
-            console.log(renderBufferFormat);
-            console.log(gl.getExtension("EXT_color_buffer_half_float"));
-            console.log(gl.getExtension("EXT_color_buffer_float"));
 
             gl.bindRenderbuffer(gl.RENDERBUFFER, colorRenderBuffer);
             gl.renderbufferStorageMultisample(

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -370,6 +370,10 @@ export function Sim(props: SimProps) {
             const renderBufferFormat = extColorBufferHalfFloat ? gl.RGBA16F : gl.RGBA;
             const renderBufferType = extColorBufferHalfFloat ? gl.HALF_FLOAT : gl.UNSIGNED_BYTE;
 
+            console.log(renderBufferFormat);
+            console.log(gl.getExtension("EXT_color_buffer_half_float"));
+            console.log(gl.getExtension("EXT_color_buffer_float"));
+
             gl.bindRenderbuffer(gl.RENDERBUFFER, colorRenderBuffer);
             gl.renderbufferStorageMultisample(
                 gl.RENDERBUFFER,

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -164,6 +164,7 @@ export function Sim(props: SimProps) {
                 type: "information/setMaxVertexUniformVectors",
                 payload: gl.getParameter(gl.MAX_VERTEX_UNIFORM_VECTORS),
             });
+            console.log(gl.getParameter(gl.MAX_VERTEX_UNIFORM_VECTORS));
             dispatch({
                 type: "information/setMaxFragmentUniformVectors",
                 payload: gl.getParameter(gl.MAX_FRAGMENT_UNIFORM_VECTORS),
@@ -173,15 +174,13 @@ export function Sim(props: SimProps) {
                 payload: gl.getParameter(gl.MAX_UNIFORM_BUFFER_BINDINGS),
             });
             dispatch({ type: "information/setMaxSamples", payload: gl.getParameter(gl.MAX_SAMPLES) });
-            let maxBufferBitDepth = "RGBA8";
-            if (gl.getExtension("EXT_color_buffer_float")) {
-                maxBufferBitDepth = "RGBA32F";
-            } else if (gl.getExtension("EXT_color_buffer_half_float")) {
-                maxBufferBitDepth = "RGBA16F";
-            }
             dispatch({
-                type: "information/setMaxBufferBitDepth",
-                payload: maxBufferBitDepth,
+                type: "information/setRgba32fSupported",
+                payload: gl.getExtension("EXT_color_buffer_float") !== null,
+            });
+            dispatch({
+                type: "information/setRgba16fSupported",
+                payload: gl.getExtension("EXT_color_buffer_half_float") !== null,
             });
 
             /*

--- a/src/redux/informationSlice.ts
+++ b/src/redux/informationSlice.ts
@@ -6,26 +6,30 @@ export interface InformationState {
     numStars: number;
     yearsElapsed: number;
     // Graphics debug variables
-    maxVertexUniformVectors: number;
-    maxFragmentUniformVectors: number;
-    maxUniformBufferBindingPoints: number;
-    maxSamples: number;
-    maxBufferBitDepth: string;
-    numActiveUniforms: number;
-    numActiveUniformVectors: number;
+    maxVertexUniformVectors: number | null;
+    maxFragmentUniformVectors: number | null;
+    maxUniformBufferBindingPoints: number | null;
+    maxSamples: number | null;
+    rgba32fSupported: boolean | null;
+    rgba16fSupported: boolean | null;
+    numActiveUniforms: number | null;
+    numActiveUniformVectors: number | null;
 }
 
 const initialState: InformationState = {
     numActiveBodies: 0,
     numStars: 0,
     yearsElapsed: 0,
-    maxVertexUniformVectors: 0,
-    maxFragmentUniformVectors: 0,
-    maxUniformBufferBindingPoints: 0,
-    maxSamples: 0,
-    maxBufferBitDepth: "",
-    numActiveUniforms: 0,
-    numActiveUniformVectors: 0,
+    // Debug variables are actually initialized by the program.
+    // Set to null here so if these dispatches fail, we can know.
+    maxVertexUniformVectors: null,
+    maxFragmentUniformVectors: null,
+    maxUniformBufferBindingPoints: null,
+    maxSamples: null,
+    rgba32fSupported: null,
+    rgba16fSupported: null,
+    numActiveUniforms: null,
+    numActiveUniformVectors: null,
 };
 
 export const informationSlice = createSlice({
@@ -50,9 +54,6 @@ export const informationSlice = createSlice({
         setMaxSamples: (state, action) => {
             state.maxSamples = action.payload;
         },
-        setMaxBufferBitDepth: (state, action) => {
-            state.maxBufferBitDepth = action.payload;
-        },
         setNumActiveUniforms: (state, action) => {
             state.numActiveUniforms = action.payload;
         },
@@ -61,6 +62,12 @@ export const informationSlice = createSlice({
         },
         setYearsElapsed: (state, action) => {
             state.yearsElapsed = action.payload;
+        },
+        setRgba32fSupported: (state, action) => {
+            state.rgba32fSupported = action.payload;
+        },
+        setRgba16fSupported: (state, action) => {
+            state.rgba16fSupported = action.payload;
         },
     },
 });

--- a/src/redux/informationSlice.ts
+++ b/src/redux/informationSlice.ts
@@ -42,10 +42,10 @@ export const informationSlice = createSlice({
         setNumStars: (state, action) => {
             state.numStars = action.payload;
         },
-        setMaxVertexUniforms: (state, action) => {
+        setMaxVertexUniformVectors: (state, action) => {
             state.maxVertexUniformVectors = action.payload;
         },
-        setMaxFragmentUniforms: (state, action) => {
+        setMaxFragmentUniformVectors: (state, action) => {
             state.maxFragmentUniformVectors = action.payload;
         },
         setMaxUniformBufferBindingPoints: (state, action) => {


### PR DESCRIPTION
Two changes here:

- Debug menu redux store variables initialized to null instead of 0 or false, to avoid confusion if WebGL fails before instantiating them with the actual values
- Separated "maxBufferBits" debug variable into "rbga16fSupported" and "rbga32fSupported", since some browsers can support 32f without supporting 16f