### PR TITLE
Better checking of WebGL extension availability for antialiasing

### DIFF
--- a/src/components/DebugStats.tsx
+++ b/src/components/DebugStats.tsx
@@ -18,8 +18,8 @@ export function DebugStats() {
             <div>Max AA Samples: {debug.maxSamples}</div>
             <div>Active Uniforms: {debug.numActiveUniforms}</div>
             <div>Active Uniform Vectors: {debug.numActiveUniformVectors}</div>
-            <h3>OpenGL Extensions</h3>
             <div>Intenal Format Used: {debug.internalFormatUsed}</div>
+            <h3>OpenGL Extensions</h3>
             <div>
                 RBGA32F Supported: {debug.rgba32fSupported !== null ? (debug.rgba32fSupported ? "TRUE" : "FALSE") : ""}
             </div>

--- a/src/components/DebugStats.tsx
+++ b/src/components/DebugStats.tsx
@@ -16,8 +16,24 @@ export function DebugStats() {
             <div>Max Fragment Uniform Vectors: {debug.maxFragmentUniformVectors}</div>
             <div>Max Uniform Buffer Binding Points: {debug.maxUniformBufferBindingPoints}</div>
             <div>Max Samples: {debug.maxSamples}</div>
-            <div>RBGA32F Supported: {debug.rgba32fSupported ? "TRUE" : "FALSE"}</div>
-            <div>RBGA16F Supported: {debug.rgba16fSupported ? "TRUE" : "FALSE"}</div>
+            <div>
+                RBGA32F Supported: {debug.rgba32fSupported !== null ? (debug.rgba32fSupported ? "TRUE" : "FALSE") : ""}
+            </div>
+            <div>
+                OES Float Linear Supported:{" "}
+                {debug.oesFloatLinearSupported !== null ? (debug.oesFloatLinearSupported ? "TRUE" : "FALSE") : ""}
+            </div>
+            <div>
+                RBGA16F Supported: {debug.rgba16fSupported !== null ? (debug.rgba16fSupported ? "TRUE" : "FALSE") : ""}
+            </div>
+            <div>
+                OES Half Float Linear Supported:{" "}
+                {debug.oesHalfFloatLinearSupported !== null
+                    ? debug.oesHalfFloatLinearSupported
+                        ? "TRUE"
+                        : "FALSE"
+                    : ""}
+            </div>
             <div>Active Uniforms: {debug.numActiveUniforms}</div>
             <div>Active Uniform Vectors: {debug.numActiveUniformVectors}</div>
         </DebugStatsStyle>

--- a/src/components/DebugStats.tsx
+++ b/src/components/DebugStats.tsx
@@ -15,7 +15,11 @@ export function DebugStats() {
             <div>Max Vertex Uniform Vectors: {debug.maxVertexUniformVectors}</div>
             <div>Max Fragment Uniform Vectors: {debug.maxFragmentUniformVectors}</div>
             <div>Max Uniform Buffer Binding Points: {debug.maxUniformBufferBindingPoints}</div>
-            <div>Max Samples: {debug.maxSamples}</div>
+            <div>Max AA Samples: {debug.maxSamples}</div>
+            <div>Active Uniforms: {debug.numActiveUniforms}</div>
+            <div>Active Uniform Vectors: {debug.numActiveUniformVectors}</div>
+            <h3>OpenGL Extensions</h3>
+            <div>Intenal Format Used: {debug.internalFormatUsed}</div>
             <div>
                 RBGA32F Supported: {debug.rgba32fSupported !== null ? (debug.rgba32fSupported ? "TRUE" : "FALSE") : ""}
             </div>
@@ -34,8 +38,6 @@ export function DebugStats() {
                         : "FALSE"
                     : ""}
             </div>
-            <div>Active Uniforms: {debug.numActiveUniforms}</div>
-            <div>Active Uniform Vectors: {debug.numActiveUniformVectors}</div>
         </DebugStatsStyle>
     );
 }

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -188,13 +188,14 @@ export function Sim(props: SimProps) {
                 payload: rgba16fSupported,
             });
             dispatch({
-                type: "information/setOesTextureFloatSupported",
+                type: "information/setOesFloatLinearSupported",
                 payload: oesTextureFloatLinearSupported,
             });
             dispatch({
-                type: "information/setOesTextureHalfFloatSupported",
+                type: "information/setOesHalfFloatLinearSupported",
                 payload: oesTextureHalfFloatLinearSupported,
             });
+            console.log(oesTextureHalfFloatLinearSupported);
 
             /*
                 Initialize all shader programs
@@ -381,7 +382,6 @@ export function Sim(props: SimProps) {
             */
 
             let renderBufferInternalFormat: GLenum = gl.RGBA8;
-
             if (rgba32fSupported && oesTextureFloatLinearSupported) {
                 renderBufferInternalFormat = gl.RGBA32F;
             } else if (rgba16fSupported && oesTextureHalfFloatLinearSupported) {

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -187,6 +187,14 @@ export function Sim(props: SimProps) {
                 type: "information/setRgba16fSupported",
                 payload: rgba16fSupported,
             });
+            dispatch({
+                type: "information/setOesTextureFloatSupported",
+                payload: oesTextureFloatLinearSupported,
+            });
+            dispatch({
+                type: "information/setOesTextureHalfFloatSupported",
+                payload: oesTextureHalfFloatLinearSupported,
+            });
 
             /*
                 Initialize all shader programs

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -384,8 +384,21 @@ export function Sim(props: SimProps) {
             let renderBufferInternalFormat: GLenum = gl.RGBA8;
             if (rgba32fSupported && oesTextureFloatLinearSupported) {
                 renderBufferInternalFormat = gl.RGBA32F;
+                dispatch({
+                    type: "information/setInternalFormatUsed",
+                    payload: "RGBA32F",
+                });
             } else if (rgba16fSupported && oesTextureHalfFloatLinearSupported) {
                 renderBufferInternalFormat = gl.RGBA16F;
+                dispatch({
+                    type: "information/setInternalFormatUsed",
+                    payload: "RGBA16F",
+                });
+            } else {
+                dispatch({
+                    type: "information/setInternalFormatUsed",
+                    payload: "RGBA8",
+                });
             }
 
             gl.bindRenderbuffer(gl.RENDERBUFFER, colorRenderBuffer);

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -372,18 +372,13 @@ export function Sim(props: SimProps) {
             // const renderBufferFormat = extColorBufferHalfFloat ? gl.RGBA16F : gl.RGBA;
             // const renderBufferType = extColorBufferHalfFloat ? gl.HALF_FLOAT : gl.UNSIGNED_BYTE;
 
-            // let renderBufferFormat: 6408 | 34842 | 34836 = gl.RGBA;
-            // let renderBufferType: 5121 | 5131 | 5126 = gl.UNSIGNED_BYTE;
+            let renderBufferInternalFormat: GLenum = gl.RGBA8;
 
-            // if (gl.getExtension("EXT_color_buffer_float")) {
-            //     renderBufferFormat = gl.RGBA32F;
-            //     renderBufferType = gl.FLOAT;
-            // } else if (gl.getExtension("EXT_color_buffer_half_float")) {
-            //     renderBufferFormat = gl.RGBA16F;
-            //     renderBufferType = gl.HALF_FLOAT;
-            // }
-
-            let renderBufferInternalFormat: GLenum = gl.RGBA32F;
+            if (rgba32fSupported && oesTextureFloatLinearSupported) {
+                renderBufferInternalFormat = gl.RGBA32F;
+            } else if (rgba16fSupported) {
+                renderBufferInternalFormat = gl.RGBA16F;
+            }
 
             gl.bindRenderbuffer(gl.RENDERBUFFER, colorRenderBuffer);
             gl.renderbufferStorageMultisample(

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -363,16 +363,28 @@ export function Sim(props: SimProps) {
             );
 
             // Check for required extensions
-            const extColorBufferHalfFloat = gl.getExtension("EXT_color_buffer_half_float");
+            //const extColorBufferHalfFloat = gl.getExtension("EXT_color_buffer_half_float");
+            // const renderBufferFormat = extColorBufferHalfFloat ? gl.RGBA16F : gl.RGBA;
+            // const renderBufferType = extColorBufferHalfFloat ? gl.HALF_FLOAT : gl.UNSIGNED_BYTE;
 
-            const renderBufferFormat = extColorBufferHalfFloat ? gl.RGBA16F : gl.RGBA;
-            const renderBufferType = extColorBufferHalfFloat ? gl.HALF_FLOAT : gl.UNSIGNED_BYTE;
+            // let renderBufferFormat: 6408 | 34842 | 34836 = gl.RGBA;
+            // let renderBufferType: 5121 | 5131 | 5126 = gl.UNSIGNED_BYTE;
+
+            // if (gl.getExtension("EXT_color_buffer_float")) {
+            //     renderBufferFormat = gl.RGBA32F;
+            //     renderBufferType = gl.FLOAT;
+            // } else if (gl.getExtension("EXT_color_buffer_half_float")) {
+            //     renderBufferFormat = gl.RGBA16F;
+            //     renderBufferType = gl.HALF_FLOAT;
+            // }
+
+            let renderBufferInternalFormat: GLenum = gl.RGBA32F;
 
             gl.bindRenderbuffer(gl.RENDERBUFFER, colorRenderBuffer);
             gl.renderbufferStorageMultisample(
                 gl.RENDERBUFFER,
                 gl.getParameter(gl.MAX_SAMPLES),
-                renderBufferFormat,
+                renderBufferInternalFormat,
                 texWidth,
                 texHeight,
             );
@@ -381,7 +393,7 @@ export function Sim(props: SimProps) {
             gl.renderbufferStorageMultisample(
                 gl.RENDERBUFFER,
                 gl.getParameter(gl.MAX_SAMPLES),
-                renderBufferFormat,
+                renderBufferInternalFormat,
                 texWidth,
                 texHeight,
             );
@@ -396,18 +408,21 @@ export function Sim(props: SimProps) {
             // Create the texture that the entire unmodified scene is rendered to
             gl.bindFramebuffer(gl.FRAMEBUFFER, colorFrameBuffer);
             const textureColorBuffer = gl.createTexture();
+
             gl.bindTexture(gl.TEXTURE_2D, textureColorBuffer);
-            gl.texImage2D(
-                gl.TEXTURE_2D,
-                0,
-                renderBufferFormat,
-                texWidth,
-                texHeight,
-                0,
-                gl.RGBA,
-                renderBufferType,
-                null,
-            );
+            // gl.texImage2D(
+            //     gl.TEXTURE_2D,
+            //     0,
+            //     renderBufferInternalFormat,
+            //     texWidth,
+            //     texHeight,
+            //     0,
+            //     gl.RGBA,
+            //     renderBufferType,
+            //     null,
+            // );
+            gl.texStorage2D(gl.TEXTURE_2D, 1, renderBufferInternalFormat, texWidth, texHeight);
+
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
             gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, textureColorBuffer, 0);
@@ -415,18 +430,21 @@ export function Sim(props: SimProps) {
             // Create the texture where only the stars are rendered (for bloom)
             gl.bindFramebuffer(gl.FRAMEBUFFER, extractFrameBuffer);
             const starExtractTexture = gl.createTexture();
+
             gl.bindTexture(gl.TEXTURE_2D, starExtractTexture);
-            gl.texImage2D(
-                gl.TEXTURE_2D,
-                0,
-                renderBufferFormat,
-                texWidth,
-                texHeight,
-                0,
-                gl.RGBA,
-                renderBufferType,
-                null,
-            );
+            // gl.texImage2D(
+            //     gl.TEXTURE_2D,
+            //     0,
+            //     renderBufferInternalFormat,
+            //     texWidth,
+            //     texHeight,
+            //     0,
+            //     gl.RGBA,
+            //     renderBufferType,
+            //     null,
+            // );
+            gl.texStorage2D(gl.TEXTURE_2D, 1, renderBufferInternalFormat, texWidth, texHeight);
+
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
@@ -447,17 +465,18 @@ export function Sim(props: SimProps) {
             for (let i = 0; i < blurFrameBuffer.length; i++) {
                 gl.bindFramebuffer(gl.FRAMEBUFFER, blurFrameBuffer[i]);
                 gl.bindTexture(gl.TEXTURE_2D, blurTextures[i]);
-                gl.texImage2D(
-                    gl.TEXTURE_2D,
-                    0,
-                    renderBufferFormat,
-                    texWidth,
-                    texHeight,
-                    0,
-                    gl.RGBA,
-                    renderBufferType,
-                    null,
-                );
+                // gl.texImage2D(
+                //     gl.TEXTURE_2D,
+                //     0,
+                //     renderBufferInternalFormat,
+                //     texWidth,
+                //     texHeight,
+                //     0,
+                //     gl.RGBA,
+                //     renderBufferType,
+                //     null,
+                // );
+                gl.texStorage2D(gl.TEXTURE_2D, 1, renderBufferInternalFormat, texWidth, texHeight);
                 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
                 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
                 gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -162,6 +162,7 @@ export function Sim(props: SimProps) {
             const rgba32fSupported = gl.getExtension("EXT_color_buffer_float") != null;
             const rgba16fSupported = gl.getExtension("EXT_color_buffer_half_float") !== null;
             const oesTextureFloatLinearSupported = gl.getExtension("OES_texture_float_linear") !== null;
+            const oesTextureHalfFloatLinearSupported = gl.getExtension("OES_texture_half_float_linear") !== null;
 
             // Set unchanging webGL debug text
             dispatch({ type: "information/setNumActiveBodies", payload: universe.current.numActive });
@@ -367,16 +368,15 @@ export function Sim(props: SimProps) {
                 texHeight,
             );
 
-            // Check for required extensions
-            //const extColorBufferHalfFloat = gl.getExtension("EXT_color_buffer_half_float");
-            // const renderBufferFormat = extColorBufferHalfFloat ? gl.RGBA16F : gl.RGBA;
-            // const renderBufferType = extColorBufferHalfFloat ? gl.HALF_FLOAT : gl.UNSIGNED_BYTE;
+            /*
+                Define MSAA render buffers
+            */
 
             let renderBufferInternalFormat: GLenum = gl.RGBA8;
 
             if (rgba32fSupported && oesTextureFloatLinearSupported) {
                 renderBufferInternalFormat = gl.RGBA32F;
-            } else if (rgba16fSupported) {
+            } else if (rgba16fSupported && oesTextureHalfFloatLinearSupported) {
                 renderBufferInternalFormat = gl.RGBA16F;
             }
 

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -158,6 +158,11 @@ export function Sim(props: SimProps) {
             // Set sorted universe parameters initially
             setLeaderboardBodies(universe.current.getActiveBodies(bodyFollowed));
 
+            // Enable necessary openGL extensions and store results
+            const rgba32fSupported = gl.getExtension("EXT_color_buffer_float") != null;
+            const rgba16fSupported = gl.getExtension("EXT_color_buffer_half_float") !== null;
+            const oesTextureFloatLinearSupported = gl.getExtension("OES_texture_float_linear") !== null;
+
             // Set unchanging webGL debug text
             dispatch({ type: "information/setNumActiveBodies", payload: universe.current.numActive });
             dispatch({
@@ -175,11 +180,11 @@ export function Sim(props: SimProps) {
             dispatch({ type: "information/setMaxSamples", payload: gl.getParameter(gl.MAX_SAMPLES) });
             dispatch({
                 type: "information/setRgba32fSupported",
-                payload: gl.getExtension("EXT_color_buffer_float") !== null,
+                payload: rgba32fSupported,
             });
             dispatch({
                 type: "information/setRgba16fSupported",
-                payload: gl.getExtension("EXT_color_buffer_half_float") !== null,
+                payload: rgba16fSupported,
             });
 
             /*

--- a/src/redux/informationSlice.ts
+++ b/src/redux/informationSlice.ts
@@ -16,6 +16,7 @@ export interface InformationState {
     oesHalfFloatLinearSupported: boolean | null;
     numActiveUniforms: number | null;
     numActiveUniformVectors: number | null;
+    internalFormatUsed: string | null;
 }
 
 const initialState: InformationState = {
@@ -34,6 +35,7 @@ const initialState: InformationState = {
     oesHalfFloatLinearSupported: null,
     numActiveUniforms: null,
     numActiveUniformVectors: null,
+    internalFormatUsed: null,
 };
 
 export const informationSlice = createSlice({
@@ -78,6 +80,9 @@ export const informationSlice = createSlice({
         },
         setOesHalfFloatLinearSupported: (state, action) => {
             state.oesHalfFloatLinearSupported = action.payload;
+        },
+        setInternalFormatUsed: (state, action) => {
+            state.internalFormatUsed = action.payload;
         },
     },
 });

--- a/src/redux/informationSlice.ts
+++ b/src/redux/informationSlice.ts
@@ -12,6 +12,8 @@ export interface InformationState {
     maxSamples: number | null;
     rgba32fSupported: boolean | null;
     rgba16fSupported: boolean | null;
+    oesTextureFloatSupported: boolean | null;
+    oesTextureHalfFloatSupported: boolean | null;
     numActiveUniforms: number | null;
     numActiveUniformVectors: number | null;
 }
@@ -28,6 +30,8 @@ const initialState: InformationState = {
     maxSamples: null,
     rgba32fSupported: null,
     rgba16fSupported: null,
+    oesTextureFloatSupported: null,
+    oesTextureHalfFloatSupported: null,
     numActiveUniforms: null,
     numActiveUniformVectors: null,
 };
@@ -68,6 +72,12 @@ export const informationSlice = createSlice({
         },
         setRgba16fSupported: (state, action) => {
             state.rgba16fSupported = action.payload;
+        },
+        setOesTextureFloatSupported: (state, action) => {
+            state.oesTextureFloatSupported = action.payload;
+        },
+        setOesTextureHalfFloatSupported: (state, action) => {
+            state.oesTextureHalfFloatSupported = action.payload;
         },
     },
 });

--- a/src/redux/informationSlice.ts
+++ b/src/redux/informationSlice.ts
@@ -12,8 +12,8 @@ export interface InformationState {
     maxSamples: number | null;
     rgba32fSupported: boolean | null;
     rgba16fSupported: boolean | null;
-    oesTextureFloatSupported: boolean | null;
-    oesTextureHalfFloatSupported: boolean | null;
+    oesFloatLinearSupported: boolean | null;
+    oesHalfFloatLinearSupported: boolean | null;
     numActiveUniforms: number | null;
     numActiveUniformVectors: number | null;
 }
@@ -30,8 +30,8 @@ const initialState: InformationState = {
     maxSamples: null,
     rgba32fSupported: null,
     rgba16fSupported: null,
-    oesTextureFloatSupported: null,
-    oesTextureHalfFloatSupported: null,
+    oesFloatLinearSupported: null,
+    oesHalfFloatLinearSupported: null,
     numActiveUniforms: null,
     numActiveUniformVectors: null,
 };
@@ -73,11 +73,11 @@ export const informationSlice = createSlice({
         setRgba16fSupported: (state, action) => {
             state.rgba16fSupported = action.payload;
         },
-        setOesTextureFloatSupported: (state, action) => {
-            state.oesTextureFloatSupported = action.payload;
+        setOesFloatLinearSupported: (state, action) => {
+            state.oesFloatLinearSupported = action.payload;
         },
-        setOesTextureHalfFloatSupported: (state, action) => {
-            state.oesTextureHalfFloatSupported = action.payload;
+        setOesHalfFloatLinearSupported: (state, action) => {
+            state.oesHalfFloatLinearSupported = action.payload;
         },
     },
 });


### PR DESCRIPTION
The program wouldn't run on Firefox. This was because of a small bug where RGBA was being set as the internal format for MSAA, where RGBA8 was needed instead. This bug exposed a larger issue, being that RGBA16F is not supported on Firefox. I had mistakenly assumed that RGBA16F had wider support than it did - I did some reading on it, and evidently RGBA32F is far more widely supported than 16F.

I had originally chosen to use RGBA16F instead of 32F because A. it solved the nasty-looking color banding issues that RGBA8 had when being lit from a far distance and B. I thought it would be more performant than 32F. However, given that it's not widely supported, I think it's best to check if 32F is available, then 16F, and fall back to 8 if needed.

RGBA32F does not degrade performance by any noticeable amount on my PC, but fear it may degrade performance on mobile devices - Further testing is needed. If I find that it does, I'll open a new issue and try to fall back to RGBA8 on lower-power devices.

closes #71