### PR TITLE
Rendering improvements of planet-scaled masses and simulation initialization changes

### DIFF
--- a/src/components/DebugStats.tsx
+++ b/src/components/DebugStats.tsx
@@ -11,6 +11,7 @@ export function DebugStats() {
             <h3>Simulation</h3>
             <div>Number of Bodies: {debug.numActiveBodies}</div>
             <div>Number of Stars: {debug.numStars}</div>
+            <div>Radius of Followed Body: {debug.followedBodyRadius}</div>
             <h3>OpenGL</h3>
             <div>Max Vertex Uniform Vectors: {debug.maxVertexUniformVectors}</div>
             <div>Max Fragment Uniform Vectors: {debug.maxFragmentUniformVectors}</div>

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -121,7 +121,7 @@ function BasicTabContent(props: TabContentProps) {
                             <td className="name">
                                 <BodySelectButton bodyIndex={body.index} bodyColor={body.color} />
                             </td>
-                            <td>{body.mass.toFixed(2)}</td>
+                            <td>{body.mass.toFixed(5)}</td>
                             <td>{body.dOrigin.toFixed(2)}</td>
                             <td>{bodyFollowed != -1 ? body.dTarget.toFixed(2) : "--"}</td>
                         </LeaderboardRowStyle>

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -3,6 +3,8 @@ import { useSelector, useDispatch } from "react-redux";
 import { RootState } from "../redux/store";
 import { useState } from "react";
 import { CircleType } from "../redux/controlsSlice";
+import { SolarSystemMassSolar } from "../lib/defines/solarSystem";
+import { MassThresholds } from "../lib/defines/physics";
 
 export function SettingsMenu() {
     const graphicsSettings = useSelector((state: RootState) => state.graphicsSettings);
@@ -13,6 +15,15 @@ export function SettingsMenu() {
 
     const [seed, setSeed] = useState(universeSettings.seed);
     const [numBodies, setNumBodies] = useState(universeSettings.numBodies);
+    const [minMass, setMinMass] = useState(universeSettings.minMass);
+    const [maxMass, setMaxMass] = useState(universeSettings.maxMass);
+    const [starInCenter, setStarInCenter] = useState(universeSettings.starInCenter);
+    const [centerStarMass, setCenterStarMass] = useState(universeSettings.centerStarMass);
+
+    const MAX_BODY_MASS = 10.0; // 10 solar masses
+    const MIN_BODY_MASS = SolarSystemMassSolar.PLUTO;
+    const MIN_STAR_MASS = MassThresholds.STAR;
+    const MAX_STAR_MASS = 100.0;
 
     return (
         <SettingsStyle>
@@ -71,6 +82,38 @@ export function SettingsMenu() {
                         setSeed(e.target.value);
                     }}
                 />
+                <div>
+                    <input
+                        type="checkbox"
+                        id="setStarInCenter"
+                        checked={starInCenter}
+                        onChange={(e) => {
+                            setStarInCenter(e.target.checked);
+                        }}
+                    />
+                    <label htmlFor="setStarInCenter">Central Star</label>
+                </div>
+                <div>
+                    <label htmlFor="centralStarMass">Mass:</label>
+                    <input
+                        type="number"
+                        value={centerStarMass}
+                        onChange={(e) => {
+                            const val = e.target.valueAsNumber;
+                            if (val < universeSettings.starThreshold) {
+                                setCenterStarMass(universeSettings.starThreshold);
+                                return;
+                            }
+                            if (val > MAX_STAR_MASS) {
+                                setCenterStarMass(MAX_STAR_MASS);
+                                return;
+                            }
+                            setCenterStarMass(e.target.valueAsNumber);
+                        }}
+                        disabled={!starInCenter}
+                    />
+                </div>
+
                 <label>Num. Grav. Bodies</label>
                 <input
                     type="number"
@@ -85,6 +128,46 @@ export function SettingsMenu() {
                     }}
                     step="1"
                 />
+                <label>Max and Min Mass</label>
+                <div>
+                    <input
+                        className="big"
+                        type="number"
+                        value={minMass}
+                        onChange={(e) => {
+                            const val = e.target.valueAsNumber;
+                            if (val > maxMass) {
+                                setMinMass(maxMass);
+                                return;
+                            }
+                            if (val < MIN_BODY_MASS) {
+                                setMinMass(MIN_BODY_MASS);
+                                return;
+                            }
+                            setMinMass(e.target.valueAsNumber);
+                        }}
+                        step="1"
+                    />
+                    <input
+                        className="big"
+                        type="number"
+                        value={maxMass}
+                        onChange={(e) => {
+                            const val = e.target.valueAsNumber;
+                            if (val < minMass) {
+                                setMaxMass(minMass);
+                                return;
+                            }
+                            if (val > MAX_BODY_MASS) {
+                                setMaxMass(MAX_BODY_MASS);
+                                return;
+                            }
+                            setMaxMass(e.target.valueAsNumber);
+                        }}
+                        step="1"
+                    />
+                </div>
+
                 <button
                     onClick={(e) => {
                         e.preventDefault();
@@ -96,6 +179,10 @@ export function SettingsMenu() {
                                 numBodies: numBodies,
                                 size: universeSettings.size,
                                 starThreshold: universeSettings.starThreshold,
+                                starInCenter: starInCenter,
+                                centerStarMass: centerStarMass,
+                                minMass: minMass,
+                                maxMass: maxMass,
                             },
                         });
                     }}
@@ -134,6 +221,10 @@ const SettingsStyle = styled.div`
 
         input[type="number"] {
             width: 3rem;
+        }
+
+        input.big {
+            width: 5rem;
         }
     }
 `;

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -100,8 +100,8 @@ export function SettingsMenu() {
                         value={centerStarMass}
                         onChange={(e) => {
                             const val = e.target.valueAsNumber;
-                            if (val < universeSettings.starThreshold) {
-                                setCenterStarMass(universeSettings.starThreshold);
+                            if (val < MIN_STAR_MASS) {
+                                setCenterStarMass(MIN_STAR_MASS);
                                 return;
                             }
                             if (val > MAX_STAR_MASS) {
@@ -178,7 +178,6 @@ export function SettingsMenu() {
                                 timeStep: universeSettings.timeStep,
                                 numBodies: numBodies,
                                 size: universeSettings.size,
-                                starThreshold: universeSettings.starThreshold,
                                 starInCenter: starInCenter,
                                 centerStarMass: centerStarMass,
                                 minMass: minMass,

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -195,7 +195,6 @@ export function Sim(props: SimProps) {
                 type: "information/setOesHalfFloatLinearSupported",
                 payload: oesTextureHalfFloatLinearSupported,
             });
-            console.log(oesTextureHalfFloatLinearSupported);
 
             /*
                 Initialize all shader programs
@@ -563,6 +562,13 @@ export function Sim(props: SimProps) {
                     dispatch({
                         type: "information/setYearsElapsed",
                         payload: universe.current.timeElapsed,
+                    });
+                    const followedBodyRadius = bodyFollowedRef.current
+                        ? universe.current.getRadius(bodyFollowedRef.current)
+                        : null;
+                    dispatch({
+                        type: "information/setFollowedBodyRadius",
+                        payload: followedBodyRadius,
                     });
                     uiAccumulatedTime = 0;
                 }

--- a/src/lib/defines/physics.tsx
+++ b/src/lib/defines/physics.tsx
@@ -2,4 +2,5 @@ export enum MassThresholds {
     GAS_GIANT = 0.00003,
     BROWN_DWARF = 0.012,
     STAR = 0.08,
+    SOLAR = 1.0,
 }

--- a/src/lib/defines/physics.tsx
+++ b/src/lib/defines/physics.tsx
@@ -1,0 +1,5 @@
+export enum MassThresholds {
+    GAS_GIANT = 0.00003,
+    BROWN_DWARF = 0.012,
+    STAR = 0.08,
+}

--- a/src/lib/universe/universe.tsx
+++ b/src/lib/universe/universe.tsx
@@ -89,14 +89,20 @@ export class Universe {
             return 0.025 * (x - MassThresholds.STAR) + h(MassThresholds.STAR);
         }
 
+        function k(x: number): number {
+            return 0.156 * (Math.pow(x, 0.57) - MassThresholds.SOLAR) + j(MassThresholds.SOLAR);
+        }
+
         if (mass <= MassThresholds.GAS_GIANT) {
             return f(mass);
         } else if (mass <= MassThresholds.BROWN_DWARF) {
             return g(mass);
         } else if (mass <= MassThresholds.STAR) {
             return h(mass);
-        } else {
+        } else if (mass <= MassThresholds.SOLAR) {
             return j(mass);
+        } else {
+            return k(mass);
         }
     }
 

--- a/src/lib/universe/universe.tsx
+++ b/src/lib/universe/universe.tsx
@@ -134,11 +134,6 @@ export class Universe {
         // const min_velocity = 0.0;
         // const max_velocity = 3;
 
-        // Masses are in solar masses
-        // For reference, the Sun's mass is 1 solar mass.
-        const min_mass = 0.001; // 0.1 solar masses
-        const max_mass = 0.1; // 1 solar mass
-
         for (let i = 0; i < this.settings.numBodies; i++) {
             // this.positionsX[i] = getRandomFloat(min_position, max_position);
             // this.positionsY[i] = getRandomFloat(-1, 1);
@@ -165,7 +160,7 @@ export class Universe {
 
             this.bodiesActive[i] = 1;
 
-            this.masses[i] = getRandomFloat(min_mass, max_mass);
+            this.masses[i] = getRandomFloat(this.settings.minMass, this.settings.maxMass);
             this.radii[i] = this.radius_from_mass_piecewise(this.masses[i]);
         }
 

--- a/src/lib/universe/universe.tsx
+++ b/src/lib/universe/universe.tsx
@@ -71,6 +71,37 @@ export class Universe {
         //return 1;
     }
 
+    public radius_from_mass_piecewise(mass: number): number {
+        const gasGiantThreshold = 0.00003;
+        const brownDwarfThreshold = 0.012;
+        const starThreshold = 0.08;
+        function f(x: number): number {
+            return 800 * x + 0.005;
+        }
+
+        function g(x: number): number {
+            return 1.8 * (x - gasGiantThreshold) + f(gasGiantThreshold);
+        }
+
+        function h(x: number): number {
+            return 0.45 * (x - brownDwarfThreshold) + g(brownDwarfThreshold);
+        }
+
+        function j(x: number): number {
+            return 0.025 * (x - starThreshold) + h(starThreshold);
+        }
+
+        if (mass <= gasGiantThreshold) {
+            return f(mass);
+        } else if (mass <= brownDwarfThreshold) {
+            return g(mass);
+        } else if (mass <= starThreshold) {
+            return h(mass);
+        } else {
+            return j(mass);
+        }
+    }
+
     public radius_from_mass_B(mass: number): number {
         const earthMassInSolarMasses = 3.003e-6;
         const jupiterMassInSolarMasses = 0.0009543;
@@ -135,7 +166,7 @@ export class Universe {
             this.bodiesActive[i] = 1;
 
             this.masses[i] = getRandomFloat(min_mass, max_mass);
-            this.radii[i] = this.radius_from_mass(this.masses[i]);
+            this.radii[i] = this.radius_from_mass_piecewise(this.masses[i]);
         }
 
         // Set colors
@@ -273,7 +304,7 @@ export class Universe {
 
                     // Merge the masses
                     this.masses[most_massive] += this.masses[less_massive];
-                    this.radii[most_massive] = this.radius_from_mass(this.masses[most_massive]);
+                    this.radii[most_massive] = this.radius_from_mass_piecewise(this.masses[most_massive]);
                     this.velocitiesX[most_massive] =
                         (this.velocitiesX[most_massive] * this.masses[most_massive] +
                             this.velocitiesX[less_massive] * this.masses[less_massive]) /

--- a/src/lib/universe/universe.tsx
+++ b/src/lib/universe/universe.tsx
@@ -3,6 +3,7 @@ import { vec3, vec4 } from "gl-matrix";
 import { LeaderboardBody } from "../../components/Leaderboard";
 import { UniverseSettings } from "../../redux/universeSettingsSlice";
 import { HSLtoRGB } from "../colors/conversions";
+import { MassThresholds } from "../defines/physics";
 
 const G = 4 * Math.PI * Math.PI; // Gravitational constant
 
@@ -72,30 +73,27 @@ export class Universe {
     }
 
     public radius_from_mass_piecewise(mass: number): number {
-        const gasGiantThreshold = 0.00003;
-        const brownDwarfThreshold = 0.012;
-        const starThreshold = 0.08;
         function f(x: number): number {
             return 800 * x + 0.005;
         }
 
         function g(x: number): number {
-            return 1.8 * (x - gasGiantThreshold) + f(gasGiantThreshold);
+            return 1.8 * (x - MassThresholds.GAS_GIANT) + f(MassThresholds.GAS_GIANT);
         }
 
         function h(x: number): number {
-            return 0.45 * (x - brownDwarfThreshold) + g(brownDwarfThreshold);
+            return 0.45 * (x - MassThresholds.BROWN_DWARF) + g(MassThresholds.BROWN_DWARF);
         }
 
         function j(x: number): number {
-            return 0.025 * (x - starThreshold) + h(starThreshold);
+            return 0.025 * (x - MassThresholds.STAR) + h(MassThresholds.STAR);
         }
 
-        if (mass <= gasGiantThreshold) {
+        if (mass <= MassThresholds.GAS_GIANT) {
             return f(mass);
-        } else if (mass <= brownDwarfThreshold) {
+        } else if (mass <= MassThresholds.BROWN_DWARF) {
             return g(mass);
-        } else if (mass <= starThreshold) {
+        } else if (mass <= MassThresholds.STAR) {
             return h(mass);
         } else {
             return j(mass);

--- a/src/lib/universe/universe.tsx
+++ b/src/lib/universe/universe.tsx
@@ -473,7 +473,7 @@ export class Universe {
         // The velocity is proportional to the distance from the center of the universe.
         const positionVector = vec3.fromValues(x, y, z);
         const perpendicularUnitVector = vec3.create();
-        vec3.cross(perpendicularUnitVector, positionVector, vec3.fromValues(0, 0, 1)); // Perpendicular to the position vector
+        vec3.cross(perpendicularUnitVector, positionVector, vec3.fromValues(0, 1, 0)); // Perpendicular to the position vector
         vec3.normalize(perpendicularUnitVector, perpendicularUnitVector); // Normalize the vector
         const distanceFromCenter = vec3.length(positionVector);
         const angularVelocityMagnitude = Math.sqrt((G * M) / distanceFromCenter); // Gravitational acceleration

--- a/src/lib/universe/universe.tsx
+++ b/src/lib/universe/universe.tsx
@@ -419,7 +419,7 @@ export class Universe {
     }
 
     public isStar(idx: number) {
-        return this.bodiesActive[idx] && this.masses[idx] >= this.settings.starThreshold;
+        return this.bodiesActive[idx] && this.masses[idx] >= MassThresholds.STAR;
     }
 
     public getStarData(): Array<vec4> {

--- a/src/lib/universe/universe.tsx
+++ b/src/lib/universe/universe.tsx
@@ -1,5 +1,5 @@
 import { getRandomFloat } from "../../random/random";
-import { vec4 } from "gl-matrix";
+import { vec3, vec4 } from "gl-matrix";
 import { LeaderboardBody } from "../../components/Leaderboard";
 import { UniverseSettings } from "../../redux/universeSettingsSlice";
 import { HSLtoRGB } from "../colors/conversions";
@@ -464,5 +464,27 @@ export class Universe {
         const U = G * (this.masses[bodyA] + this.masses[bodyB]);
 
         return 0.5 * v * v - U / r;
+    }
+
+    /*
+        Getters
+    */
+    public getRadius(idx: number): number {
+        return this.radii[idx];
+    }
+    public getMass(idx: number): number {
+        return this.masses[idx];
+    }
+    public getPositionX(idx: number): number {
+        return this.positionsX[idx];
+    }
+    public getPosition(idx: number): vec3 {
+        return vec3.fromValues(this.positionsX[idx], this.positionsY[idx], this.positionsZ[idx]);
+    }
+    public getVelocity(idx: number): vec3 {
+        return vec3.fromValues(this.velocitiesX[idx], this.velocitiesY[idx], this.velocitiesZ[idx]);
+    }
+    public getAcceleration(idx: number): vec3 {
+        return vec3.fromValues(this.accelerationsX[idx], this.accelerationsY[idx], this.accelerationsZ[idx]);
     }
 }

--- a/src/random/random.tsx
+++ b/src/random/random.tsx
@@ -3,3 +3,7 @@ export function getRandomFloat(min: number, max: number): number {
     // For now, I'll lazily use Math.random().
     return Math.random() * (max - min) + min;
 }
+
+export function getRandomInt(min: number, max: number): number {
+    return Math.floor(getRandomFloat(min, max));
+}

--- a/src/redux/informationSlice.ts
+++ b/src/redux/informationSlice.ts
@@ -5,6 +5,7 @@ export interface InformationState {
     numActiveBodies: number;
     numStars: number;
     yearsElapsed: number;
+    followedBodyRadius: number | null;
     // Graphics debug variables
     maxVertexUniformVectors: number | null;
     maxFragmentUniformVectors: number | null;
@@ -23,6 +24,7 @@ const initialState: InformationState = {
     numActiveBodies: 0,
     numStars: 0,
     yearsElapsed: 0,
+    followedBodyRadius: null,
     // Debug variables are actually initialized by the program.
     // Set to null here so if these dispatches fail, we can know.
     maxVertexUniformVectors: null,
@@ -83,6 +85,9 @@ export const informationSlice = createSlice({
         },
         setInternalFormatUsed: (state, action) => {
             state.internalFormatUsed = action.payload;
+        },
+        setFollowedBodyRadius: (state, action) => {
+            state.followedBodyRadius = action.payload;
         },
     },
 });

--- a/src/redux/universeSettingsSlice.ts
+++ b/src/redux/universeSettingsSlice.ts
@@ -6,6 +6,8 @@ export interface UniverseSettings {
     numBodies: number; // THe number of starting bodies in the universe
     size: number; // The size of the universe in astronomical units
     starThreshold: number;
+    minMass: number;
+    maxMass: number;
 }
 
 const initialState: UniverseSettings = {
@@ -13,7 +15,9 @@ const initialState: UniverseSettings = {
     timeStep: 1.0 / 12.0, // time step in years (1 month)
     numBodies: 500,
     size: 20, // The size of the universe in astronomical units|
-    starThreshold: 0.8,
+    starThreshold: 0.08,
+    minMass: 0.001,
+    maxMass: 0.1,
 };
 
 export const universeSettingsSlice = createSlice({

--- a/src/redux/universeSettingsSlice.ts
+++ b/src/redux/universeSettingsSlice.ts
@@ -6,7 +6,6 @@ export interface UniverseSettings {
     timeStep: number;
     numBodies: number; // THe number of starting bodies in the universe
     size: number; // The size of the universe in astronomical units
-    starThreshold: number;
     starInCenter: boolean;
     centerStarMass: number;
     minMass: number;
@@ -17,8 +16,7 @@ const initialState: UniverseSettings = {
     seed: "irrelevant",
     timeStep: 1.0 / 12.0, // time step in years (1 month)
     numBodies: 500,
-    size: 20, // The size of the universe in astronomical units|
-    starThreshold: 0.08,
+    size: 20, // The size of the universe in astronomical units
     starInCenter: true,
     centerStarMass: 1.0,
     minMass: SolarSystemMassSolar.MARS,
@@ -34,7 +32,6 @@ export const universeSettingsSlice = createSlice({
             state.timeStep = action.payload.timeStep;
             state.numBodies = action.payload.numBodies;
             state.size = action.payload.size;
-            state.starThreshold = action.payload.starThreshold;
             state.starInCenter = action.payload.starInCenter;
             state.centerStarMass = action.payload.centerStarMass;
             state.minMass = action.payload.minMass;

--- a/src/redux/universeSettingsSlice.ts
+++ b/src/redux/universeSettingsSlice.ts
@@ -35,6 +35,10 @@ export const universeSettingsSlice = createSlice({
             state.numBodies = action.payload.numBodies;
             state.size = action.payload.size;
             state.starThreshold = action.payload.starThreshold;
+            state.starInCenter = action.payload.starInCenter;
+            state.centerStarMass = action.payload.centerStarMass;
+            state.minMass = action.payload.minMass;
+            state.maxMass = action.payload.maxMass;
         },
     },
 });

--- a/src/redux/universeSettingsSlice.ts
+++ b/src/redux/universeSettingsSlice.ts
@@ -7,6 +7,8 @@ export interface UniverseSettings {
     numBodies: number; // THe number of starting bodies in the universe
     size: number; // The size of the universe in astronomical units
     starThreshold: number;
+    starInCenter: boolean;
+    centerStarMass: number;
     minMass: number;
     maxMass: number;
 }
@@ -17,6 +19,8 @@ const initialState: UniverseSettings = {
     numBodies: 500,
     size: 20, // The size of the universe in astronomical units|
     starThreshold: 0.08,
+    starInCenter: true,
+    centerStarMass: 1.0,
     minMass: SolarSystemMassSolar.MARS,
     maxMass: SolarSystemMassSolar.JUPITER,
 };

--- a/src/redux/universeSettingsSlice.ts
+++ b/src/redux/universeSettingsSlice.ts
@@ -1,4 +1,5 @@
 import { createSlice } from "@reduxjs/toolkit";
+import { SolarSystemMassSolar } from "../lib/defines/solarSystem";
 
 export interface UniverseSettings {
     seed: string;
@@ -16,8 +17,8 @@ const initialState: UniverseSettings = {
     numBodies: 500,
     size: 20, // The size of the universe in astronomical units|
     starThreshold: 0.08,
-    minMass: 0.001,
-    maxMass: 0.1,
+    minMass: SolarSystemMassSolar.MARS,
+    maxMass: SolarSystemMassSolar.JUPITER,
 };
 
 export const universeSettingsSlice = createSlice({


### PR DESCRIPTION
Previously, my simulation had a mass range of 0.001 and 0.1 solar masses, and was rendered to look good using those masses. However, as I mentioned in #59, these masses are way out-of-whack when compared to actual solar system body masses. I've made a few changes to make this more in-line with reality:

- I've cobbled together a piecewise function to scale planetary radii such that they're visible but still visually-distinct from each other. The piecewise function is divided into five pieces: Terrestrial planets, Gas giants, Brown dwarves, Stars < 1 solar mass, Stars > 1 solar mass. The first 4 scale linearly, each one more gradually than the last. Stars past 1 solar mass scale at some fraction of x^0.57, which is based in physics. I'll probably end up messing with these values more in the future, but for now, it's pretty neat. You can see the graph of the piecewise function I worked on here: [Desmos Graph](https://www.desmos.com/calculator/i2r2ul1heh)
- I made a better getInitialVelocity function. My last function was a poorly-made thing where I was misapplying [mean orbital speed](https://en.wikipedia.org/wiki/Orbital_speed#Mean_orbital_speed) with vectors. I did some reading, and now it's properly vectorized. As long as there's a star in the middle, all of the bodies follow along in a nice circular orbit from the start!
- I added sim settings "Add Central Star" and "Central Star Mass". Self-explanatory.
- I added some new settings to control the masses of bodies. It's a bit janky though, given the extremely wide ranges of mass (0.00001 to 1) - I'll want to find some way to improve this. Maybe add a toggle for units?

Something to note: With these changes, the default system is not nearly as chaotic as before. I want to add some sort of settings preset that can maintain this stable system, as well as create a chaotic simulation like the previous simulation had. It might necessitate optimizing our rendering process so we can get more than 500 bodies on screen without lagging terribly.

closes #61 
closes #62 
closes #63 