### PR TITLE
Leaderboard performance improvements

### DIFF
--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -24,7 +24,7 @@ export interface LeaderboardBody {
     orbiting: number;
     dOrbit: number;
     orbitColor: string;
-    numSattelites: number;
+    numSatellites: number;
 }
 
 export interface LeaderboardProps {
@@ -40,7 +40,8 @@ export function Leaderboard(props: LeaderboardProps) {
     const { leaderboardBodies } = props;
     const [sortCriteria, setSortCriteria] = useState<SortCriteria>({ type: SortType.MASS, ascending: false });
     const sortedBodies = useMemo(() => {
-        return sortBodies(leaderboardBodies, sortCriteria);
+        const sorted = sortBodies(leaderboardBodies, sortCriteria);
+        return sorted;
     }, [sortCriteria, leaderboardBodies]);
 
     const [activeTab, setActiveTab] = useState<string>(LeaderboardTabType.BASIC);
@@ -180,7 +181,7 @@ function OrbitTabContent(props: TabContentProps) {
                             <td className="name">
                                 <BodySelectButton bodyIndex={body.index} bodyColor={body.color} />
                             </td>
-                            <td>{body.numSattelites}</td>
+                            <td>{body.numSatellites}</td>
                             <td className={body.orbiting != -1 ? "name" : ""}>
                                 {body.orbiting != -1 ? (
                                     <BodySelectButton bodyIndex={body.orbiting} bodyColor={body.orbitColor} />
@@ -407,7 +408,7 @@ interface SortCriteria {
 }
 
 function sortBodies(bodies: LeaderboardBody[], criteria: SortCriteria): LeaderboardBody[] {
-    return bodies.sort((a, b) => {
+    return bodies.toSorted((a, b) => {
         if (criteria.type === SortType.NAME) {
             return criteria.ascending ? a.index - b.index : b.index - a.index;
         } else if (criteria.type === SortType.MASS) {
@@ -438,8 +439,8 @@ function sortBodies(bodies: LeaderboardBody[], criteria: SortCriteria): Leaderbo
                 : b.dOrbit - a.dOrbit || a.index - b.index;
         } else if (criteria.type === SortType.NUM_SAT) {
             return criteria.ascending
-                ? a.numSattelites - b.numSattelites || a.index - b.index
-                : b.numSattelites - a.numSattelites || a.index - b.index;
+                ? a.numSatellites - b.numSatellites || a.index - b.index
+                : b.numSatellites - a.numSatellites || a.index - b.index;
         } else {
             // Default case for MASS in descending order
             return b.mass - a.mass;

--- a/src/components/Leaderboard.tsx
+++ b/src/components/Leaderboard.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { useMemo, useState } from "react";
+import { Profiler, useMemo, useState } from "react";
 import { brightenColor } from "../lib/colors/brightenColor";
 import { RadioButtonCheckedIcon } from "../assets/icons/RadioButtonCheckedIcon";
 import { RadioButtonUncheckedIcon } from "../assets/icons/RadioButtonUncheckedIcon";
@@ -48,22 +48,24 @@ export function Leaderboard(props: LeaderboardProps) {
 
     return (
         <Menu tabs={leaderboardTabs} activeTab={activeTab} setActiveTab={setActiveTab}>
-            <LeaderboardContent>
-                {activeTab == LeaderboardTabType.BASIC && (
-                    <BasicTabContent
-                        sortedBodies={sortedBodies}
-                        sortCriteria={sortCriteria}
-                        setSortCriteria={setSortCriteria}
-                    />
-                )}
-                {activeTab == LeaderboardTabType.ORBIT && (
-                    <OrbitTabContent
-                        sortedBodies={sortedBodies}
-                        sortCriteria={sortCriteria}
-                        setSortCriteria={setSortCriteria}
-                    />
-                )}
-            </LeaderboardContent>
+            <Profiler id="Leaderboard" onRender={() => {}}>
+                <LeaderboardContent>
+                    {activeTab == LeaderboardTabType.BASIC && (
+                        <BasicTabContent
+                            sortedBodies={sortedBodies}
+                            sortCriteria={sortCriteria}
+                            setSortCriteria={setSortCriteria}
+                        />
+                    )}
+                    {activeTab == LeaderboardTabType.ORBIT && (
+                        <OrbitTabContent
+                            sortedBodies={sortedBodies}
+                            sortCriteria={sortCriteria}
+                            setSortCriteria={setSortCriteria}
+                        />
+                    )}
+                </LeaderboardContent>
+            </Profiler>
         </Menu>
     );
 }
@@ -113,14 +115,15 @@ function BasicTabContent(props: TabContentProps) {
             </thead>
             <tbody>
                 {sortedBodies.map((body: LeaderboardBody) => {
+                    const isFollowedBody = bodyFollowed == body.index;
                     return (
-                        <LeaderboardRowStyle
-                            key={body.index}
-                            bodyColor={body.color}
-                            selected={bodyFollowed == body.index}
-                        >
+                        <LeaderboardRowStyle key={body.index} bodyColor={body.color} selected={isFollowedBody}>
                             <td className="name">
-                                <BodySelectButton bodyIndex={body.index} bodyColor={body.color} />
+                                <BodySelectButton
+                                    bodyIndex={body.index}
+                                    bodyColor={body.color}
+                                    selected={isFollowedBody}
+                                />
                             </td>
                             <td>{body.mass.toFixed(5)}</td>
                             <td>{body.dOrigin.toFixed(2)}</td>
@@ -172,19 +175,24 @@ function OrbitTabContent(props: TabContentProps) {
             </thead>
             <tbody>
                 {sortedBodies.map((body: LeaderboardBody) => {
+                    const isFollowedBody = bodyFollowed == body.index;
                     return (
-                        <LeaderboardRowStyle
-                            key={body.index}
-                            bodyColor={body.color}
-                            selected={bodyFollowed == body.index}
-                        >
+                        <LeaderboardRowStyle key={body.index} bodyColor={body.color} selected={isFollowedBody}>
                             <td className="name">
-                                <BodySelectButton bodyIndex={body.index} bodyColor={body.color} />
+                                <BodySelectButton
+                                    bodyIndex={body.index}
+                                    bodyColor={body.color}
+                                    selected={isFollowedBody}
+                                />
                             </td>
                             <td>{body.numSatellites}</td>
                             <td className={body.orbiting != -1 ? "name" : ""}>
                                 {body.orbiting != -1 ? (
-                                    <BodySelectButton bodyIndex={body.orbiting} bodyColor={body.orbitColor} />
+                                    <BodySelectButton
+                                        bodyIndex={body.orbiting}
+                                        bodyColor={body.orbitColor}
+                                        selected={isFollowedBody}
+                                    />
                                 ) : (
                                     <>None</>
                                 )}
@@ -325,24 +333,24 @@ const LeaderboardSortHeaderStyle = styled.th<{ selected: boolean }>`
 interface BodySelectButtonProps {
     bodyIndex: number;
     bodyColor: string;
+    selected: boolean;
 }
 
 function BodySelectButton(props: BodySelectButtonProps) {
-    const { bodyIndex, bodyColor } = props;
-    const bodyFollowed = useSelector((state: RootState) => state.controls.bodyFollowed);
+    const { bodyIndex, bodyColor, selected } = props;
     const dispatch = useDispatch();
     return (
         <BodySelectButtonStyle
             onClick={() => {
                 dispatch({
                     type: "controls/setBodyFollowed",
-                    payload: bodyFollowed == bodyIndex ? -1 : bodyIndex,
+                    payload: selected ? -1 : bodyIndex,
                 });
             }}
-            selected={bodyIndex == bodyFollowed}
+            selected={selected}
             bodyColor={bodyColor}
         >
-            {bodyIndex == bodyFollowed ? (
+            {selected ? (
                 <RadioButtonCheckedIcon filled={false} color={"black"} dim={"1rem"} />
             ) : (
                 <RadioButtonUncheckedIcon filled={false} color={"black"} dim={"1rem"} />

--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -558,9 +558,12 @@ export function Sim(props: SimProps) {
                 */
                 uiAccumulatedTime += deltaTime;
                 if (uiAccumulatedTime >= uiThrottleTime) {
-                    setLeaderboardBodies(universe.current.getActiveBodies(bodyFollowedRef.current));
-                    dispatch({ type: "information/setNumActiveBodies", payload: universe.current.numActive });
-                    dispatch({ type: "information/setNumStars", payload: universe.current.getNumStars() });
+                    if (!pausedRef.current) {
+                        setLeaderboardBodies(universe.current.getActiveBodies(bodyFollowedRef.current));
+                        dispatch({ type: "information/setNumActiveBodies", payload: universe.current.numActive });
+                        dispatch({ type: "information/setNumStars", payload: universe.current.getNumStars() });
+                    }
+
                     dispatch({
                         type: "information/setNumActiveUniforms",
                         payload: starLightRef.current

--- a/src/lib/universe/universe.tsx
+++ b/src/lib/universe/universe.tsx
@@ -401,14 +401,15 @@ export class Universe {
     }
 
     public getActiveBodies(target: number): Array<LeaderboardBody> {
-        const massRankings = new Array<LeaderboardBody>(this.settings.numBodies);
+        const massRankings = new Array<LeaderboardBody>(this.numActive);
+        let j = 0;
         for (let i = 0; i < this.settings.numBodies; i++) {
             // Skip inactive bodies
             if (!this.bodiesActive[i]) {
                 continue;
             }
 
-            massRankings[i] = {
+            massRankings[j] = {
                 index: i,
                 mass: this.masses[i],
                 color: `rgb(${this.colorsR[i] * 255}, ${this.colorsG[i] * 255}, ${this.colorsB[i] * 255})`,
@@ -417,8 +418,10 @@ export class Universe {
                 orbiting: this.orbitalIndices[i],
                 dOrbit: this.orbitalDistances[i],
                 orbitColor: `rgb(${this.colorsR[this.orbitalIndices[i]] * 255}, ${this.colorsG[this.orbitalIndices[i]] * 255}, ${this.colorsB[this.orbitalIndices[i]] * 255})`,
-                numSattelites: this.numSattelites[i],
+                numSatellites: this.numSattelites[i],
             };
+
+            j++;
         }
 
         return massRankings;

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -1,9 +1,9 @@
 {
     "compilerOptions": {
         "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
-        "target": "ES2020",
+        "target": "ES2024",
         "useDefineForClassFields": true,
-        "lib": ["ES2020", "DOM", "DOM.Iterable"],
+        "lib": ["ES2024", "DOM", "DOM.Iterable"],
         "module": "ESNext",
         "skipLibCheck": true,
 


### PR DESCRIPTION
As I mentioned in #75 , I noticed some serious performance degredation when the leaderboard was opened. It appears that this is only the case in strict mode. Here's some performance charts using the new counters implemented in #78 :

| | Prod | Dev |
| --- | --- | --- |
| FPS, Leaderboard Closed | 140 | 140 |
| FPS, Leaderboard Open | 140 | 10 |
| TPS, Leaderboard Closed | 60 | 60 |
| TPS, Leaderboard Open | 60 | 60

Even though prod is unaffected, I dug in and found some bugs and other possible issues.

Some changes so far:

- I switched the Typescript target from ES2020 to ES2024. This gives us access to some nice modern functions, like toSorted().

- I fixed an issue where the leaderboard array was being sorted an unecessary number of times. Bodies.sort() was sorting leaderboardBodies in place, which triggered useMemo() because leaderboardBodies was changed as a result of being sorted. I switched over to useSorted() instead.

- I fixed a critical issue where getActiveBodies was returning a full numBodies sized array with holes of undefined data instead of a continuous array of numActiveBodies size. This was previously undiscovered because sort() will skip over undefined values and return a sorted array without them. toSorted() does no such thing.

- Got rid of useSelector inside of the button selector components in favor of passing in a prop, since the parent componet calls it anyway and re-renders all of the buttons.

Even though strict mode leaderboard performance isn't quite resolved, I'm going to close #75 and focus on something else.

closes #75 