### PR TITLE
fix: simulation no longer hangs on tab-in

### DIFF
--- a/src/components/Sim.tsx
+++ b/src/components/Sim.tsx
@@ -536,12 +536,23 @@ export function Sim(props: SimProps) {
                 // Tick stuff
 
                 //Update the universe simulation
-                while (accumulatedTime >= secondsPerTick) {
+                const maxUpdatesAllowedAtOnce = 30;
+                let updatesThisFrame = 0;
+                while (accumulatedTime >= secondsPerTick && updatesThisFrame < maxUpdatesAllowedAtOnce) {
                     if (!pausedRef.current) {
                         universe.current.updateEuler(secondsPerTick);
                         tickCount++;
                     }
                     accumulatedTime -= secondsPerTick;
+                    updatesThisFrame++;
+                }
+
+                if (updatesThisFrame === maxUpdatesAllowedAtOnce && accumulatedTime > 0) {
+                    console.log(
+                        `Simulation capped at ${maxUpdatesAllowedAtOnce} updates this frame.`,
+                        `Dropping ${accumulatedTime.toFixed(3)}s of accumulated time (likely due to tab-out).`,
+                    );
+                    accumulatedTime = 0;
                 }
 
                 // Measure TPS every second


### PR DESCRIPTION
This long-standing problem has finally been fixed. It's a quick solution that caps the number of allowed updates to 30. Eventually, it would be nice to allow the simulation to continue in the background - But for now, a hanging program is unacceptable, so this is a good fix.

closes #46 